### PR TITLE
subtree update: 59bf24f178 -> 4459c6b6a6

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,13 +2,13 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 52f07a4b0b193b9a6eb9090a6a65f5e82f7dced5
+last_revision = 0164b4ca7adaa2946890ffedc67101c3e4e8ed7f
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 0782ea454af5b88cd686ac572c397d92e5912de4
+last_revision = ce0b93fc1235f53fbe528e5f6835f8d1b1803331
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi


### PR DESCRIPTION
meta-openembedded 0782ea454a -> ce0b93fc12:
    applied 8f5d1be19856... python3-gevent: Avoid building internal version of libev
    applied bac3fe527a2d... tio: added tio version 2.0 and 1.47
    applied d46416895805... freeradius: fix daemon startup warnings
    applied 8803be17aada... libsdl: add CVE-2019-14906 to allowlist
    applied b53a59f3261e... bpftool: add aarch64 to COMPATIBLE_HOST
    applied cdc175009d16... libwebsockets: add optional support for sd-event loop
    applied f6846875916e... frr: upgrade 8.2.2 -> 8.3.1
    applied 26ad773c4c74... gst-instruments: Update 0.2.3 -> 0.3.1+cb8977a
    applied 39c40a361a60... libftdi: Add ftdi-eeprom support
    applied 1e4be4c8078c... xf86-video-ati: Update 19.1.0 -> 19.1.0+7a6a34af
    applied ce35e5fb9c4e... faad2: Upgrade 2.8.8 -> 2.10.0
    applied 8480f29d18df... onig: Upgrade 6.9.4 -> 6.9.8
    applied 3efcb4c5f8fe... gerbera: upgrade 1.9.2 -> 1.11.0
    applied 757a636ae278... fmt: upgrade 8.1.1 -> 9.1.0
    applied 3e1007146c8d... xterm: upgrade 372 -> 373
    applied 5ce7a2a89b94... xterm: Add _GNU_SOURCE via CFLAGS
    applied 333cdd80c694... libnftnl: upgrade 1.2.2 -> 1.2.3
    applied b07db09fe8e6... nftables: upgrade 1.0.4 -> 1.0.5
    applied 0e30cdf9a9b1... libnet: update to v1.2 release
    applied ff7666cae8b3... v4l-utils: Update 1.22.1 -> 1.23.0+fd544473
    applied 479b1455e37d... plymouth: uprev to 22.02.122
    applied f3fa2a5d5c02... libwebsockets: add error check if PACKAGECONFIG contains systemd but DISTRO_FEATURES doesn't
    applied 4b26cded9c74... jansson: Honour multilib paths
    applied 7361f9f75f85... jansson: Backport linker flag fixes
    applied ce0b93fc1235... jansson: Default to shared builds
meta-arm 52f07a4b0b -> 0164b4ca7a:
    applied 1f7e8b6de90a... gem5/linux-yocto: upgrade to 5.4.205 and fix buildpaths in binaries
    applied c039d1601f7b... arm-bsp: trusted-services: fix openamp build
    applied c27462f2ae28... arm-bsp/ffa-debugfs: update git SHA for v2.1.0
    applied 941881935894... arm-bsp/optee-os: add 3.10 recipe for corstone1000
    applied 503bfcdc363c... arm-bsp/optee: rename corstone1000 files
    applied 9ce653966084... arm/optee-spdevkit: add version to file name
    applied 7a13b2e3f9d2... arm-bsp/external-system:corstone1000: build and install external-system
    applied 23266ea6fbdb... arm-bsp/n1sdp-board-firmware: upgrade to N1SDP-2022.06.22
    applied 261263a6701a... arm-toolchain/gcc,external-arm-toolchain: resolve conflict with gcc headers
    applied 7c3e597b4c61... arm/packagegroup-ts-tests: fix parse error
    applied 820a55d348ba... arm/lib: Specify the FVP environment variables explicitly
    applied 1182b0d2ea74... arm-bsp/u-boot: Add external system driver to u-boot device tree
    applied b086301d4621... arm-bsp/kernel: Add external device driver
    applied 18e68367e058... arm-bsp/tc: upgrade version of trusted-firmware-a
    applied 3b48207cc760... arm-bsp/tc: upgrade version of hafnium
    applied a9a53e258a02... arm-bsp/tc: upgrade version of optee
    applied fde0575aeac3... edk2-firmware: Fix configure sed typo
    applied a3f22f90bb72... arm/optee-os: add ARMv7 changes to clang patch and update patches
    applied dfd03ca1a354... arm/qemuarm-secureboot: remove optee-os version pin
    applied 606e7d4c4e2f... arm/optee: remove old versions
    applied abc8b4fe162a... arm/optee-client: move the 3.14 recipe to meta-arm-bsp
    applied c6bf835cefed... arm/hafnium: update to 2.7
    applied 7d8b25240515... optee-os: Extend clang pragma fixes to core_mmu_v7.c for 3.18
    applied 2c2ed8f727fa... trusted-services: Pin to use gcc
    applied a0658a6682a5... ffa-debugfs-mod: Exclude from world builds
    applied cf5bccb0d62b... arm-bsp/n1sdp: update linux-yocto patches
    applied 9f532a8cbd50... arm/edk2-firmware: Work around clang issue
    applied b573b29b766f... arm-bsp/u-boot: Add external system MHUs to u-boot device tree
    applied be8890bb034c... arm-bsp/kernel: Add rpmsg_arm_mailbox to corstone1000
    applied 75ccc7847d8a... linux-yocto: Add bbappend for 5.19
    applied 04b78e80b071... hafnium: Add a fix for clang-15 errors
    applied 4c3a7eec7e0d... arm-bsp/tc: remove hafnium clang patch
    applied 037011da6490... arm-bsp/test: Adding a test app for external system
    applied 4a190f18def7... arm-bsp/images: Adding external system test to initramfs image
    applied f51323750027... Temporary use qemu 7.0.0 for TS CI pipelines
    applied 680954d6e90a... arm-bsp/n1sdp: upgrade scp-firmware version
    applied 4cd8d73788a9... hafnium: Exclude from world builds
    applied 1dc0baf42135... arm/fvp-base-r-aem: upgrade to version 11.19.14
    applied 40c0c47134aa... Revert "Temporary use qemu 7.0.0 for TS CI pipelines"
    applied 0c002d467eb3... arm-bsp/u-boot: add gnutls-native as dependency
    applied a816bcc8ab4d... arm-bsp/trusted-firmware-a: add firmware update support for TC
    applied 3f59a344e66d... arm-bsp/hafnium: enable Virtual Host Extension for TC
    applied aa89fe3f08cb... runfvp: pass-through environment variables need for GUI applications
    applied 2c9cf626223c... layers: convert to langdale compatibility
    applied d7ef05a2fead... arm-bsp/edk2-firmware: Update edk2/edk2-platforms versions for N1SDP
    applied 4f6a200997f6... arm-bsp/edk2-firmware: Add edk2-platforms patches for N1SDP
    applied 7f05bd643123... arm-bsp/trusted-firmware-a: Update TF-A version for N1SDP
    applied 8d0410782e25... CI: Remove uniquely zephyr machines
    applied f25935371da2... arm-bsp/test: Changing the test app repository
    applied 6ef4d3ef1877... arm-bsp/external-system: Changing the RTX repo
    applied ff4a322c838f... arm-bsp/trusted-firmware-m: Make branch names configurable
    applied 97c7e9f08e66... arm/classes: Migrate TF-M image signing to bbclass
    applied fc26f65b1ca2... arm-bsp/corstone1000: Refactor image signing to use new bbclass
    applied 63c7e60c1e03... arm-bsp/u-boot: corstone1000: update initramfs bundle size
    applied 607166e3bda5... arm-bsp/u-boot: corstone1000: upgrade FF-A support
    applied 8817e91e5d55... arm-bsp/optee-os: corstone1000: upgrade to v3.18
    applied f483fcfc68a9... arm-bsp/optee-spdevkit: corstone1000: drop the support
    applied 56d53d439391... arm-bsp/corstone1000-initramfs-image: remove obsolete packages
    applied 36536b605576... arm-bsp/trusted-services: corstone1000: add secure partitions support
    applied 068c2f37c050... arm-bsp/machine: corstone1000: disable pulling the kernel into the initramfs
    applied 37a9dbc5b79d... arm-bsp/trusted-services: corstone1000: add MHU-driver
    applied ddbf0addf144... arm-bsp/corstone1000-initramfs-image: add TS PSA API tests packages
    applied 126eebcabd9d... arm-bsp/linux: corstone1000: use arm-ffa machine feature
    applied 7a42f5c64238... arm/secure-partitions: drop use of the recipe
    applied 04a7ba3c77b6... arm/ffa-debugfs: drop use of the kernel module
    applied 6655928c8151... arm-bsp/fvp: move the fvp include file to the include directory
    applied 6983e2a2a99e... ci: move features only needed by testimage from base
    applied b64ea83aef1b... CI: apply a patch so that meta-zephyr is compatible with langdale
    applied 0164b4ca7ada... Revert "CI: apply a patch so that meta-zephyr is compatible with langdale"

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
