### PR TITLE
subtree update: bdfb8a9ceb -> 2194f503e1

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 0164b4ca7adaa2946890ffedc67101c3e4e8ed7f
+last_revision = 13199c55c013c6f303258bf9a32d289211fe6a5c
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = ce0b93fc1235f53fbe528e5f6835f8d1b1803331
+last_revision = 6529e5f9630a0879b7735bf867e2a27cee717c57
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 45d56d82b785c50a7c3d6ae3e75908ef78d3ce60
+last_revision = fc5f80a47ed7761509ac0700c81581c97dfe135a
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = 824d2762f6d8705e42af9035580d931610e56ee6
+last_revision = e8e731818928fcc822688a53d244a98ef5f02488
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 5200799866b92259e855051112520006e1aaaac0
+last_revision = 3e5faccfaf50fee0ba8f6eef6c9bf458137d06d2
 


### PR DESCRIPTION
meta-arm 0164b4ca7a -> 13199c55c0:
    applied df99894eaa... arm-toolchain: update Arm GCC to 11.3
    applied 6001998caa... external-arm-toolchain: Enable 11.3.rel1 support
    applied 38a3facd90... arm-bsp/corstone1000: bump kernel version to 5.19
    applied 00bd768ab7... meta-arm/trusted-services: Use GCC toolchain for specific TS recipes only.
    applied 932db44b20... arm/optee-spdevkit: remove
    applied bb1a229176... arm-bsp/linux-yocto: Upgrade kernel to v5.19 for N1SDP
    applied 797e43e09b... arm-bsp/corstone500: upgrade kernel to v5.19
    applied 987966a587... arm-bsp/linux-yocto: update RPMSG_CTRL config for corstone1000
    applied 09a3e899dc... CI: trusted services as a feature instead of a machine
    applied 1bc064e020... CI: cleanups for targets and removed tests
    applied 3921257e9b... arm: update Android common kernel
    applied b9073fdc99... arm-bsp/linux-arm64-ack: make it compatible with gcc-12 for TC
    applied 545ba524b8... arm-bsp: zephyr removal
    applied dc4c85ccbb... arm/trusted-services: Remove patches merged upstream
    applied cbcb1bf39d... CI: restrict compression threading
    applied f8aba2d5f3... arm/trusted-services: Remove remaining patches merged upstream
    applied 90f9e1241b... arm/trusted-services: include documentation
    applied d87c445b24... arm/lib: Do not log FVP return codes < 0
    applied 60af2fc053... arm-bsp/u-boot: corstone1000: esrt support
    applied 81181ed898... arm-bsp/trusted-firmware-m: corstone1000: bump tfm SHA
    applied 0f49cad85f... arm-bsp/trusted-firmware-m: corstone1000: fix sournce dir of libmetal and openamp
    applied 37ba0b162a... arm-bsp/trusted-firmware-m: corstone1000: secure debug code checkout from yocto
    applied 13199c55c0... arm-bsp/kernel: Fix TEE driver bug for corstone1000
meta-raspberrypi 45d56d82b7 -> fc5f80a47e:
    applied d3cdc30958... rpi-cmdline: Leave cma value to kernel default
    applied 5edbd17c5b... libcamera: Tweak to build for Raspberry Pi
    applied acb2f73e58... rpi-libcamera-apps: add new recipe
    applied 757d88af9f... lirc: rename bbappend to match 0.10.%
    applied c573499166... ci: fix typo: unconditionally
    applied fc5f80a47e... ci: fix apparent typo in file patterns
meta-openembedded ce0b93fc12 -> 6529e5f963:
    applied 3d65e0460c... opcua: Add new recipe
    applied 111e73d712... open62541: Disable lto on riscv/clang
    applied 0f6a6a3cc9... mbedtls: Fix CVE product name
    applied e726f388b2... mbedtls: Update to 2.28.1 version
    applied e2188ac73b... mbedtls: Whitelist CVE-2021-43666, CVE-2021-45451
    applied ef4fb2211e... paho-mqtt-c: upgrade 1.3.10 -> 1.3.11
    applied 9ab32b214b... libcamera: Bump SRCREV and add libyaml to DEPENDS
    applied 09b329a485... python3-cchardet: depend on cython
    applied 8a4a47286d... python3-gevent: make compatible with python 3.11
    applied 7b2503f531... python3-pybluez: add python 3.11 patch
    applied 0902fc043c... python3-networkx: Upgrade 2.8.6 -> 2.8.7
    applied b5ec019f2b... python3-coverage: Upgrade 6.4.4 -> 6.5.0
    applied b63f18b6f0... python3-rdflib: Upgrade 6.1.1 -> 6.2.0
    applied aab662c994... spitools: remove unused BPV variable
    applied 6b7cf95e75... opencv: fix reproducibility issues
    applied 22682fdfb7... chrony: add pkgconfig class as pkg-config is explicitly searched for
    applied aa20821f17... chrony: correct parameter to configure to disable readline usage
    applied bdb8742459... x265: support aarch64
    applied be3c3f73d5... python3-tabulate: Upgrade 0.8.10 -> 0.9.0
    applied 6bb394265d... python3-imageio: Upgrade 2.22.0 -> 2.22.1
    applied d3900ea057... tio: correct license information
    applied b52dd2da8d... re2: fix branch name from master to main
    applied b6be90d70b... strongswan: upgrade 5.9.7 -> 5.9.8
    applied 6beace44e7... ctags: upgrade 5.9.20220925.0 -> 5.9.20221002.0
    applied ee1cd31896... dnfdragora: upgrade 2.1.2 -> 2.1.3
    applied ad0362ea2e... dool: upgrade 1.0.0 -> 1.1.0
    applied 5666061116... freeglut: upgrade 3.2.1 -> 3.4.0
    applied 7b0f9e5355... gspell: upgrade 1.11.1 -> 1.12.0
    applied 88498ea247... hwdata: upgrade 0.362 -> 0.363
    applied 7be2695d13... iperf3: upgrade 3.11 -> 3.12
    applied 19fe729689... libnet-dns-perl: upgrade 1.34 -> 1.35
    applied b1287c4ef2... lirc: upgrade 0.10.1 -> 0.10.2
    applied 525dbf76ab... metacity: upgrade 3.44.0 -> 3.46.0
    applied 3ada70df7c... flatbuffers: upgrade 2.0.8 -> 22.9.29
    applied ee7e06f3aa... opencl-headers: upgrade 2022.09.23 -> 2022.09.30
    applied d5dbee665a... php: upgrade 8.1.10 -> 8.1.11
    applied 7d6daf2ee2... poppler: upgrade 22.09.0 -> 22.10.0
    applied 4facf6815c... mariadb: not use qemu to run cross-compiled binaries
    applied 5c59497531... libcamera: Remove boost from DEPENDS
    applied 3dde6003ab... xfstests: upgrade 2022.09.04 -> 2022.09.25
    applied 5bb861f591... links: upgrade 2.27 -> 2.28
    applied 7666b0a59b... st: upgrade 0.8.5 -> 0.9
    applied a4f2646ef2... python3-requests-toolbelt: upgrade 0.9.1 -> 0.10.0
    applied 45293254f4... python3-protobuf: upgrade 4.21.6 -> 4.21.7
    applied 4ea9e26918... stunnel: upgrade 5.65 -> 5.66
    applied 6627312b01... python3-web3: upgrade 5.31.0 -> 5.31.1
    applied 6829378d00... wolfssl: upgrade 5.5.0 -> 5.5.1
    applied a0570e0c43... python3-xmlschema: upgrade 2.1.0 -> 2.1.1
    applied 8ae057a2e6... openldap: Upgrade 2.5.12 -> 2.5.13
    applied 7cd9307271... open-vm-tools: upgrade 11.3.5 -> 12.1.0
    applied 3f2d6f897b... python3-astroid: Upgrade 2.12.10 -> 2.12.11
    applied 3fda6ca362... python3-jsonref: Upgrade 0.2 -> 0.3.0
    applied 022e65ccd4... spice: Include aarch64 to COMPATIBLE_HOST
    applied 5978937bb3... python3-sentry-sdk: Upgrade 1.5.12 -> 1.9.10
    applied c157c78b84... jack: fix compatibility with python-3.11
    applied 354608cb88... dhcp-relay: upgrade 4.4.3 -> 4.4.3-P1
    applied 8ac152e9e8... python3-gevent: Upgrade to 22.8.0
    applied df5249f75d... Add nativesdk-systemd-systemctl as dependency of dnf-plugin-tui
    applied 8d83f7f391... dnf-plugin-tui: Add nativesdk
    applied 96c0d6210a... python3-greenlet: Upgrade 1.1.3 -> 1.1.3.post0
    applied 2467e6c82d... python3-xmltodict: Upgrade 0.12.0 -> 0.13.0
    applied 6e2cfa4113... mctp: install the .target files
    applied 9628ca83c2... frr: Security fix CVE-2022-37032
    applied 3b32cfc181... blueman: upgrade 2.2.4 -> 2.3.2
    applied 6529e5f963... gtkmm3: upgrade 3.24.5 -> 3.24.7
meta-security 824d2762f6 -> e8e7318189:
    applied 014f9dab78... tpm: update the linux-yocto rule with the one from sanity-meta-tpm class
    applied 852daaf67b... apparmor: update to 3.0.7
    applied b29ce7d47d... libgssglue: update to 0.7
    applied e8e7318189... cryptmount: update to 6.0
poky 5200799866 -> 3e5faccfaf:
    applied c3c7344826... migration guides: 3.4: remove spurious space in example
    applied 9dbd27a48a... manuals: improve initramfs details
    applied 104f20717c... migration guides: add release notes for 4.0.4
    applied 84251f8d24... manuals: add references to the "do_fetch" task
    applied 9fece9c361... manuals: add reference to the "do_install" task
    applied edaa121c7b... manuals: add references to the "do_build" task
    applied 5d1e8104cd... manuals: add reference to "do_configure" task
    applied 6ade5d2d0e... manuals: add reference to the "do_compile" task
    applied 0e8d0ecc6c... manuals: add references to the "do_deploy" task
    applied 3c6b2798a0... manuals: add references to the "do_image" task
    applied b3dc55b051... manuals: add references to the "do_package" task
    applied 67a72fc3f7... manuals: add references to the "do_package_qa" task
    applied 020c44eb3b... overview-manual: concepts.rst: add reference to "do_packagedata" task
    applied a6a7676910... manuals: add references to the "do_patch" task
    applied ec31647110... manuals: add references to "do_package_write_*" tasks
    applied 2102333157... ref-manual: variables.rst: add reference to "do_populate_lic" task
    applied 97495b4c89... manuals: add reference to the "do_populate_sdk" task
    applied 8f39d1812b... overview-manual: concepts.rst: add reference to "do_populate_sdk_ext" task
    applied a8b6712dfd... manuals: add references to "do_populate_sysroot" task
    applied c9c7ace795... manuals: add references to the "do_unpack" task
    applied c99fdab612... dev-manual: common-tasks.rst: add reference to "do_clean" task
    applied 66a523d7e7... manuals: add references to the "do_cleanall" task
    applied 2aae1accee... ref-manual: tasks.rst: add references to the "do_cleansstate" task
    applied ba478645a3... manuals: add references to the "do_devshell" task
    applied 6660c0603a... dev-manual: common-tasks.rst: add reference to "do_listtasks" task
    applied b42af6aa4a... manuals: add references to the "do_bundle_initramfs" task
    applied 40b7725212... manuals: add references to the "do_rootfs" task
    applied c4e05c5223... ref-manual: tasks.rst: add reference to the "do_kernel_checkout" task
    applied 3784c57c04... manuals: add reference to the "do_kernel_configcheck" task
    applied 5f5d993bae... manuals: add references to the "do_kernel_configme" task
    applied e95e686e0c... ref-manual: tasks.rst: add reference to the "do_kernel_metadata" task
    applied 623720dcf4... migration-guides: add reference to the "do_shared_workdir" task
    applied 4d2159d107... ref-manual: tasks.rst: add reference to the "do_validate_branches" task
    applied 9d597ea614... ref-manual: tasks.rst: add reference to the "do_image_complete" task
    applied f2803414b9... ref-manual: system-requirements: Ubuntu 22.04 now supported
    applied ba08db9817... overview-manual: concepts.rst: fix formating and add references
    applied 3e5faccfaf... ref-manual/faq.rst: update references to products built with OE / Yocto Project

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
