### PR TITLE
honister: subtree update: a515de07df -> 46fc02f393

### DIFF
--- a/honister.conf
+++ b/honister.conf
@@ -2,7 +2,7 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = honister
-last_revision = 9a0caf5b09e14a28a54c3f8524d97530aeb8152c
+last_revision = 0e6c34f82ca4d43cbca3754c5fe37c5b3bdd0f37
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
@@ -20,5 +20,5 @@ last_revision = fb77606aef461910db4836bad94d75758cc2688c
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = honister
-last_revision = eff78b3802ffa7a0bff4c839752b147712da63ac
+last_revision = fd00d74f47ceb57a619c4d0a0553ff0a30bbb7a4
 


### PR DESCRIPTION
meta-openembedded 9a0caf5b09 -> 0e6c34f82c:
    applied 05f84dbc36f... imlib2: update SRC_URI
    applied 0e6c34f82ca... ostree: prevent ostree-native depending on target virtual/kernel to provide kernel-module-overlay
poky eff78b3802 -> fd00d74f47:
    applied 4337b18725a... scripts/runqemu: Fix memory limits for qemux86-64
    applied 0f139080f62... unzip: fix CVE-2021-4217
    applied a18c4104c83... vim: Upgrade 8.2.4524 -> 8.2.4681
    applied 00534dd1369... linux-yocto/5.10: update to v5.10.109
    applied 401c83d4f88... pseudo: Fix handling of absolute links
    applied b19991bf95a... xz: fix CVE-2022-1271
    applied e262633f640... uninative: Upgrade to 3.6 with gcc 12 support
    applied b5a4c322a1e... tiff: Add marker for CVE-2022-1056 being fixed
    applied 1deb7e3145b... externalsrc/devtool: Fix to work with fixed export funcition flags handling
    applied 0abe6ebd002... libxshmfence: Correct LICENSE to HPND
    applied fd344392501... license_image.bbclass: close package.manifest file
    applied 638784c71fc... gmp: add missing COPYINGv3
    applied 9766e3609dd... alsa-tools: Ensure we install correctly
    applied 2b0bb2d78a0... u-boot: Inherit pkgconfig
    applied 53c727195df... linux-firmware: upgrade 20220310 -> 20220411
    applied 47249787742... wireless-regdb: upgrade 2022.02.18 -> 2022.04.08
    applied 8d6afadf48d... linux-firmware: correct license for ar3k firmware
    applied ef827a4a5d3... shadow-native: Simplify and fix syslog disable patch
    applied 7d210474da1... poky.conf: bump version for 3.4.4 release
    applied 99e1aff4ba4... documentation: update for 3.4.4 release
    applied 638c8860eba... bitbake: knotty: display active tasks when printing keepAlive() message
    applied ce323dd1a92... bitbake: knotty: reduce keep-alive timeout from 5000s (83 minutes) to 10 minutes
    applied 3f17ee4ebef... bitbake.conf: mark all directories as safe for git to read
    applied 780eeec8851... build-appliance-image: Update to honister head revision
    applied d6d549a0e4c... busybox: Use base_bindir instead of hardcoding /bin path
    applied 2b2002a294c... cases/buildepoxy.py: fix typo
    applied 431002a1361... neard: Switch SRC_URI to git repo
    applied 8402f346fc1... rootfs-postcommands: fix symlinks where link and output path are equal
    applied 1b0306978cc... volatile-binds: Change DefaultDependencies from false to no
    applied 609d6de7451... oeqa/selftest: add test for git working correctly inside pseudo
    applied 87bd34033a5... base: Avoid circular references to our own scripts
    applied 663939ef27a... install/devshell: Introduce git intercept script due to fakeroot issues
    applied 5f685dc2d1d... base: Drop git intercept
    applied 0a4e32274fa... scripts: Make git intercept global
    applied 3e48263df5e... scripts/git: Ensure we don't have circular references
    applied 188059a9c5e... lttng-modules: update to 2.13.1
    applied fd032a2db3a... lttng-modules: upgrade 2.13.1 -> 2.13.2
    applied c24a700b1a4... lttng-modules: upgrade 2.13.2 -> 2.13.3
    applied ffb6c5c902c... lttng-modules: support kernel 5.18+
    applied 8a0766f6f50... perf: sort-pmuevents: don't drop elements
    applied 17ea8b493d6... perf: sort-pmuevents: allow for additional type qualifiers and storage class
    applied 51cb23e695c... adding missing space in appends
    applied 5350a0162c4... linux-firmware: upgrade 20220411 -> 20220509
    applied e28a432c27a... vim: Upgrade 8.2.4681 -> 8.2.4912
    applied e87c8d0eda4... linux-yocto/5.10: features/security: Move x86_64 configs to separate file
    applied a37aa8a3b13... linux-yocto/5.10: update to v5.10.110
    applied 0eac4658994... linux-yocto/5.10: base: enable kernel crypto userspace API
    applied 0f2839bb8c5... linux-yocto/5.10: update to v5.10.112
    applied 44849be60d5... wic/plugins/rootfs: Fix permissions when splitting rootfs folders across partitions
    applied be0eb43a36d... openssl: upgrade 1.1.1l -> 1.1.1n
    applied 06232bc56b6... openssl: Minor security upgrade 1.1.1n to 1.1.1o
    applied a71d6fe1718... linux-yocto: enable powerpc debug fragment
    applied c701ce82d12... linux-yocto: Enable powerpc-debug fragment for ppc64 LE
    applied 25c5b987e44... linux-yocto/5.10: update to v5.10.113
    applied fd00d74f47c... yocto-bsps: update to v5.10.113

openbmc-subtree update -c honister.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
