### PR TITLE
dunfell: subtree update: cddccf4ad5 -> 61a2d43a17

### DIFF
--- a/dunfell.conf
+++ b/dunfell.conf
@@ -92,7 +92,7 @@ last_revision = 168440a0f1c89fc8ef6cabea033c5611d323df89
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = dunfell
-last_revision = f22bf6efaae61a8fd9272be64e7d75223c58922e
+last_revision = 6792ebdd966aa0fb662989529193a0940fbfee00
 
 [meta-openpower]
 src_uri = https://gerrit.openbmc-project.xyz/openbmc/meta-openpower
@@ -158,5 +158,5 @@ last_revision = 7eef85ee0d2e6f8100c06c0f9a9cb52c941ecd50
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = dunfell
-last_revision = 4aad5914efe9789755789856882aac53de6c4ed3
+last_revision = 90a6f6a110ab14890e2f6a1616e74ee259fc0f8f
 


### PR DESCRIPTION
meta-openembedded f22bf6efaa -> 6792ebdd96:
    applied e5e63be86e2... python3-lxml: CVE-2022-2309 NULL Pointer Dereference allows attackers to cause a denial of service
    applied a1a40c95ebf... nodejs: Upgrade to 12.22.12
    applied a33dca52979... cryptsetup: upgrade 2.3.2 -> 2.3.7
    applied 87841f0c186... Revert "c-ares: Add fix for CVE-2021-3672"
    applied de05a500b9e... c-ares: Upgrade to 1.17.1 release
    applied cd8d2f689fd... c-ares: upgrade 1.17.1 -> 1.17.2
    applied ad1dcf68b6c... c-ares: remove custom patches
    applied 6792ebdd966... c-ares: upgrade 1.17.2 -> 1.18.1
poky 4aad5914ef -> 90a6f6a110:
    applied eaf8d5efa0c... bitbake: bitbake: runqueue: add cpu/io pressure regulation
    applied afd213cc8e7... bitbake: bitbake: runqueue: add memory pressure regulation
    applied adc49cb9600... bitbake: runqueue: Change pressure file warning to a note
    applied bc294f9573e... ref-manual: add numa to machine features
    applied 87377eacc0a... bitbake: utils: Pass lock argument in fileslocked
    applied dea6f2c8472... libtiff: CVE-2022-34526 A stack overflow was discovered
    applied 8bc3443c081... golang: fix CVE-2022-30629 and CVE-2022-30631
    applied 7d67a61029c... golang: fix CVE-2022-30632 and CVE-2022-30633
    applied 1a1eceee49a... golang: fix CVE-2022-30635 and CVE-2022-32148
    applied 964b78a02d7... golang: CVE-2022-32189 a denial of service
    applied 211a3fd4db3... libxml2: Add fix for CVE-2016-3709
    applied fb9e6d51d4e... cve-check: Don't use f-strings
    applied 1cf135da980... vim: Upgrade 9.0.0115 -> 9.0.0242
    applied c4692956ea0... mobile-broadband-provider-info: upgrade 20220511 -> 20220725
    applied 3d435421bc1... tzdata: upgrade 2022a -> 2022b
    applied beda4837050... wireless-regdb: upgrade 2022.06.06 -> 2022.08.12
    applied b16301db9a7... linux-yocto/5.4: update to v5.4.210
    applied e576212d25e... cryptodev-module: fix build with 5.11+ kernels
    applied a884e8bdbf9... relocate_sdk.py: ensure interpreter size error causes relocation to fail
    applied d24759196aa... sqlite: CVE-2022-35737 assertion failure
    applied 8f4bbd93591... curl: Backport patch for CVE-2022-35252
    applied a5de603a1b9... libarchive: Fix CVE-2021-23177 issue
    applied 85637f30f37... libarchive: Fix CVE-2021-31566 issue
    applied 7ba4ed6f5fc... classes: cve-check: Get shared database lock
    applied 0bee2e95b71... cve-check: close cursors as soon as possible
    applied 0566db5c82a... vim: Upgrade 9.0.0242 -> 9.0.0341
    applied b9c73d65916... python3: Fix CVE-2021-28861 for python3
    applied a98b309fe23... tiff: Fix for CVE-2022-2867/8/9
    applied 5e7c237200c... tiff: Security fixes CVE-2022-1354 and CVE-2022-1355
    applied 459d081bf82... connman: fix CVE-2022-32292
    applied 9ca32cf9abc... gnutls: fix CVE-2021-4209
    applied 0781ad69b89... virglrenderer: fix CVE-2022-0135
    applied a14af03441a... systemd: Fix unwritable /var/lock when no sysvinit handling
    applied a69227932f3... systemd: Add 'no-dns-fallback' PACKAGECONFIG option
    applied aa19c8c35e5... binutils : CVE-2022-38533
    applied e49990f01e5... gst-plugins-good: fix several CVE
    applied 2fa8edea5a7... go: fix and ignore several CVEs
    applied 537de1798b2... vim: Upgrade 9.0.0341 -> 9.0.0453
    applied 65cf3249fa1... linux-yocto/5.4: update genericx86* machines to v5.4.205
    applied 8b52687223c... sqlite3: Fix CVE-2020-35525
    applied 10c6b704c09... sqlite3: Fix CVE-2020-35527
    applied 20087e04b32... connman: CVE-2022-32293 man-in-the-middle attack against a WISPR HTTP
    applied b44d2090439... qemu: fix and ignore several CVEs
    applied 9cc9232e31d... qemu: Define libnfs PACKAGECONFIG
    applied f9a63709b08... qemu: Add PACKAGECONFIG for brlapi
    applied a8ee7ba022e... subversion: fix CVE-2021-28544
    applied 915a752d378... sqlite3: Fix CVE-2021-20223
    applied 2fef664dd9d... expat: Fix CVE-2022-40674
    applied 134ac61730f... linux-yocto/5.4: update to v5.4.212
    applied d7194226b19... linux-yocto/5.4: update to v5.4.213
    applied 243a95b193a... inetutils: CVE-2022-39028 - fix remote DoS vulnerability in inetutils-telnetd
    applied 483ab0979f0... vim: Upgrade 9.0.453 -> 9.0.541
    applied 35aaf7eadd6... tzdata: Update from 2022b to 2022c
    applied ca1c4e7a76a... linux-firmware: upgrade 20220708 -> 20220913
    applied 1956baac108... linux-firmware: package new Qualcomm firmware
    applied fb7acc1b214... linux-firmware: package new Qualcomm firmware
    applied e9ad2aab5ce... bluez: CVE-2022-39176 BlueZ allows physically proximate attackers
    applied f50439feb5b... vim: Upgrade 9.0.0541 -> 9.0.0598
    applied 95ba88b9354... golang: CVE-2022-27664 net/http: handle server errors after sending GOAWAY
    applied aa449287a0d... go: Add fix for CVE-2022-32190
    applied 028971709f4... create-pull-request: don't switch the git remote protocol to git://
    applied 4d8f22bc239... bind: Fix CVEs 2022-2795, 2022-38177, 2022-38178
    applied d7019b183d0... licenses: Handle newer SPDX license names
    applied 8cf3492f4c8... documentation: update for 3.1.20
    applied 9ae91384970... poky.conf: bump version for 3.1.20 release
    applied 7f9b7f912e1... build-appliance-image: Update to dunfell head revision
    applied 90a6f6a110a... dev-manual: fix reference to BitBake user manual

openbmc-subtree update -c dunfell.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
