### PR TITLE
kirkstone: subtree update: 53fdac2b0a -> c67ef227fe

### DIFF
--- a/kirkstone.conf
+++ b/kirkstone.conf
@@ -2,13 +2,13 @@
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = kirkstone
-last_revision = acbe74879807fc6f82b62525d32c823899e19036
+last_revision = 744a4b6eda88b9a9ca1cf0df6e18be384d9054e3
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = kirkstone
-last_revision = 0135a02ea577bd39dd552236ead2c5894d89da1d
+last_revision = dacad9302a92b0b7edf8546cdcad1f8ef753e462
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -20,5 +20,5 @@ last_revision = c79262a30bd385f5dbb009ef8704a1a01644528e
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = kirkstone
-last_revision = 387ab5f18b17c3af3e9e30dc58584641a70f359f
+last_revision = eaf8ce9d39a2c0d9c42b32fb6596ab4302f93a1a
 


### PR DESCRIPTION
poky 387ab5f18b -> eaf8ce9d39:
    applied d7e5f28f51e... gdk-pixbuf: CVE-2021-46829 a heap-based buffer overflow
    applied 66575e31b76... qemu: fix CVE-2021-3507
    applied 73080b3372d... qemu: fix CVE-2021-3929
    applied c2c7ab07415... qemu: fix CVE-2021-4158
    applied 29ee816927a... qemu: fix CVE-2022-0358
    applied 1d9d4e54c9f... qemu: fix CVE-2022-0216
    applied ee5b810f663... u-boot: fix CVE-2022-33103
    applied 33e296554e3... gnutls: CVE-2022-2509 Double free during gnutls_pkcs7_verify
    applied b65989b835f... zlib: CVE-2022-37434 a heap-based buffer over-read
    applied 73618dee225... vim: update from 9.0.0063 to 9.0.0115
    applied 58d3e1b8976... devtool: error out when workspace is using old override syntax
    applied 53019423e47... devtool/upgrade: correctly clean up when recipe filename isn't yet known
    applied 0ff2b0bbf84... devtool/upgrade: catch bb.fetch2.decodeurl errors
    applied cb87867c476... runqemu: Add missing space on default display option
    applied 23ebe696765... archiver.bbclass: remove unsed do_deploy_archives[dirs]
    applied d8c792f12c5... create-spdx: Fix supplier field
    applied 4d51fda5430... create-spdx: ignore packing control files from ipk and deb
    applied d4dc48175a2... boost: fix install of fiber shared libraries
    applied d73e6bf0157... cmake: remove CMAKE_ASM_FLAGS variable in toolchain file
    applied ac8186042de... scripts/oe-setup-builddir: make it known where configurations come from
    applied 36eb09d20ed... nativesdk: Clear TUNE_FEATURES
    applied 84eb7f3b984... relocate_sdk.py: ensure interpreter size error causes relocation to fail
    applied 778241eff56... selftest/wic: Tweak test case to not depend on kernel size
    applied 6d8c1d0a949... lttng-modules: fix 5.19+ build
    applied 848585c96f6... lttng-modules: fix build against mips and v5.19 kernel
    applied 744d68c3697... lttng-modules: replace mips compaction fix with upstream change
    applied 3b184381661... bitbake: bitbake: runqueue: add cpu/io pressure regulation
    applied 2e193726bd1... bitbake: bitbake: runqueue: add memory pressure regulation
    applied 1fc9f7da25a... bitbake: runqueue: Change pressure file warning to a note
    applied c87dd3d310c... libtiff: CVE-2022-34526 A stack overflow was discovered
    applied a6065e7120e... libxml2: Ignore CVE-2016-3709
    applied ee16bcef39e... connman: Backports for security fixes
    applied c78d028649c... u-boot: fix CVE-2022-30552
    applied a46516486f2... u-boot: fix CVE-2022-33967
    applied aa1c8a2b701... grub2: fix several CVEs
    applied 6413ed11f83... cve-check: Don't use f-strings
    applied 55139508f26... go: update v1.17.12 -> v1.17.13
    applied e0df847541b... bluez5: update 5.64 -> 5.65
    applied 8cc22b745e3... libwpe: upgrade 1.12.0 -> 1.12.2
    applied 467b0536aab... ell: upgrade 0.49 -> 0.50
    applied a3e099e8a0b... iso-codes: upgrade 4.10.0 -> 4.11.0
    applied 407bb733876... libcap: upgrade 2.63 -> 2.64
    applied 7f288475f55... libcap: upgrade 2.64 -> 2.65
    applied 7a44d093992... libwebp: upgrade 1.2.2 -> 1.2.3
    applied fa705f6a8b8... mobile-broadband-provider-info: upgrade 20220511 -> 20220725
    applied 430ad987d44... webkitgtk: upgrade 2.36.4 -> 2.36.5
    applied 3e3e985aba7... weston: upgrade 10.0.1 -> 10.0.2
    applied e25377627d5... python3-pip: Fix RDEPENDS after the update
    applied b331a332416... cracklib: Drop using register keyword
    applied 81eb70494a8... tcp-wrappers: Fix implicit-function-declaration warnings
    applied 2900394c894... libpam: use /run instead of /var/run in systemd tmpfiles
    applied 6cde70a0857... perf: Fix reproducibility issues with 5.19 onwards
    applied 20ebf632176... archiver.bbclass: some recipes that uses the kernelsrc bbclass uses the shared source
    applied 9e3f81eac0b... apt: fix nativesdk-apt build failure during the second time build
    applied 4084c93c6af... linux-yocto: prepend the the value with a space when append to KERNEL_EXTRA_ARGS
    applied df99f61e05c... create-spdx: handle links to inaccessible locations
    applied 29ed4d50253... packagegroup-self-hosted: update for strace
    applied 2140cd390f5... vim: Upgrade 9.0.0115 -> 9.0.0242
    applied b051dc5d4f7... ref-manual: add numa to machine features
    applied e0c806a65c8... migration guides: add missing release notes
    applied 7f1145b315b... linux-yocto/5.15: update genericx86* machines to v5.15.59
    applied 79730b06c83... linux-yocto/5.10: update genericx86* machines to v5.10.135
    applied 2c910432907... tzdata: upgrade 2022a -> 2022b
    applied bc3ef76f40b... xz: update 5.2.5 -> 5.2.6
    applied 992a4cfd10e... Revert "gdk-pixbuf: CVE-2021-46829 a heap-based buffer overflow"
    applied 6ee4d6ed719... gdk-pixbuf: upgrade 2.42.6 -> 2.42.8
    applied 12c38aea92e... gdk-pixbuf: update 2.42.8 -> 2.42.9
    applied a0c8c576a36... epiphany: upgrade 42.3 -> 42.4
    applied edc290cddf3... glib-networking: upgrade 2.72.1 -> 2.72.2
    applied 74e8b2e1403... libjpeg-turbo: upgrade 2.1.3 -> 2.1.4
    applied 64113a48320... libwebp: upgrade 1.2.3 -> 1.2.4
    applied 38874f50909... wireless-regdb: upgrade 2022.06.06 -> 2022.08.12
    applied af01a36c232... wpebackend-fdo: upgrade 1.12.0 -> 1.12.1
    applied bb8d474166f... sysvinit-inittab/start_getty: Fix respawn too fast
    applied 371147d7c08... kernel-fitimage.bbclass: only package unique DTBs
    applied 1983fc67f50... oeqa/parselogs: add qemuarmv5 arm-charlcd masking
    applied ed9a6adb5de... package_rpm: Do not replace square brackets in %files
    applied 7712782d90a... sanity: add a comment to ensure CONNECTIVITY_CHECK_URIS is correct
    applied 672187ff65c... oeqa/qemurunner: add run_serial() comment
    applied 00e2ab0852d... oeqa/selftest: rename git.py to intercept.py
    applied d45b3be4bff... oeqa/gotoolchain: put writable files in the Go module cache
    applied 79668237c93... oeqa/gotoolchain: set CGO_ENABLED=1
    applied 8191b791234... wic: add target tools to PATH when executing native commands
    applied cd88865fd29... wic/bootimg-efi: use cross objcopy when building unified kernel image
    applied 366fde882fc... wic: depend on cross-binutils
    applied a6fe1dab21b... bitbake: utils: Pass lock argument in fileslocked
    applied 51fa7708574... sqlite: fix CVE-2022-35737
    applied 50599a43779... bind: upgrade 9.18.4 -> 9.18.5
    applied 0ee1456ab29... linux-yocto/5.15: update to v5.15.60
    applied 520fca8908f... linux-yocto/5.15: update to v5.15.62
    applied 2823418c13d... linux-yocto: Fix COMPATIBLE_MACHINE regex match
    applied 7cb1e0c9999... linux-yocto/5.10: update to v5.10.136
    applied ff17c6bc7a0... linux-yocto/5.10: update to v5.10.137
    applied b74a9df4624... lttng-modules: fix build for kernel 5.10.137
    applied 5ec20bf952a... shadow: Enable subid support
    applied c917d00ea33... rootfspostcommands.py: Cleanup subid backup files generated by shadow-utils
    applied 5f3999c41a4... shadow: Avoid nss warning/error with musl
    applied df982d10580... util-linux: Remove --enable-raw from EXTRA_OECONF
    applied 328e343baaa... parselogs: Ignore xf86OpenConsole error
    applied 079ccabcaf3... xinetd: Pass missing -D_GNU_SOURCE
    applied fa2cc0b97b3... watchdog: Include needed system header for function decls
    applied 7b0a2f46f75... pinentry: enable _XOPEN_SOURCE on musl for wchar usage in curses
    applied 93a0fcc7c98... apr: Use correct strerror_r implementation based on libc type
    applied 9ccb0bd0d5f... gcr: Define _GNU_SOURCE
    applied 12e2869bcff... bitbake: toaster: fix kirkstone version
    applied 2c42fa484a6... sqlite: add CVE-2022-35737 patch to SRC_URI
    applied 68dfce5f526... curl: Backport patch for CVE-2022-35252
    applied 72aa63fcf5f... binutils : CVE-2022-38533
    applied 8856232de42... classes: cve-check: Get shared database lock
    applied 4384b8a13ae... cve-check: close cursors as soon as possible
    applied df6c07aa0e5... vim: Upgrade 9.0.0242 -> 9.0.0341
    applied fdee7be50f5... libtasn1: upgrade 4.18.0 -> 4.19.0
    applied 46a7341426e... liburcu: upgrade 0.13.1 -> 0.13.2
    applied 668db849829... libwpe: upgrade 1.12.2 -> 1.12.3
    applied 634e86bc246... libatomic-ops: upgrade 7.6.12 -> 7.6.14
    applied 2d582eaef41... lz4: upgrade 1.9.3 -> 1.9.4
    applied 164d127e112... insane.bbclass: Skip patches not in oe-core by full path
    applied 4bca2a8318c... maintainers: update opkg maintainer
    applied 2723b8dae83... apr: Cache configure tests which use AC_TRY_RUN
    applied bdc6dfc12fc... bitbake.conf: set BB_DEFAULT_UMASK using ??=
    applied 5cc976671b2... pseudo: Update to include recent upstream minor fixes
    applied 2a82c3d93a1... scripts/runqemu.README: fix typos and trailing whitespaces
    applied ce82f937d84... meta: introduce UBOOT_MKIMAGE_KERNEL_TYPE
    applied b7d5addf56c... kernel-fitimage.bbclass: add padding algorithm property in config nodes
    applied c5feaa51203... npm: replace 'npm pack' call by 'tar czf'
    applied 54962ac3a96... npm: return content of 'package.json' in 'npm_pack'
    applied dcf593b7a6e... npm: take 'version' directly from 'package.json'
    applied bf1987dbe54... lib:npm_registry: initial checkin
    applied b53aff215ef... npm: use npm_registry to cache package
    applied 74883eca07d... bitbake: runqueue: Fix unihash cache mismatch issues
    applied a18a0145111... bitbake: cooker: Drop sre_constants usage
    applied 870d4c950bc... bitbake: event.py: ignore exceptions from stdout and sterr operations in atexit
    applied f58e385b99e... bitbake: ConfHandler: Remove lingering close
    applied df626c9cc07... bitbake: bitbake-user-manual: Correct description of the ??= operator
    applied 7fe30a0445d... bitbake: doc: bitbake-user-manual: add explicit target for crates fetcher
    applied e3fd45f0cfb... bitbake: doc: bitbake-user-manual: document npm and npmsw fetchers
    applied 43e98fb4551... bitbake: fetch2: gitsm: fix incorrect handling of git submodule relative urls
    applied 34ce1874911... bitbake: ConfHandler/BBHandler: Improve comment error messages and add tests
    applied 9c26cd5d704... bitbake: fetch2: Ensure directory exists before creating symlink
    applied 957522d50f5... bitbake: bitbake: bitbake-user-manual: hashserv can be accessed on a dedicated domain
    applied fe2c27108af... bitbake: bb/utils: remove: check the path again the expand python glob
    applied 62539509982... bitbake: bb/utils: movefile: use the logger for printing
    applied 18d0f1011c6... bitbake: bitbake-user-manual: npm fetcher: improve description of SRC_URI format
    applied 4b608efe9ab... cracklib: upgrade 2.9.7 -> 2.9.8
    applied c74ea5f8444... vala: upgrade 0.56.2 -> 0.56.3
    applied 10ed98e50f3... ruby: drop capstone support
    applied 1cee07e8e94... gcc-multilib-config: Fix i686 toolchain relocation issues
    applied 9df448f8437... kernel: Always set CC and LD for the kernel build
    applied 7c17784fcc3... kernel: Use consistent make flags for menuconfig
    applied 17d6955673c... autoconf: Fix strict prototype errors in generated tests
    applied d67a572a424... autoconf: Update K & R stype functions
    applied 5367b62d7cd... libxml2: Port gentest.py to Python-3
    applied f604ff9de4b... core-image.bbclass: Exclude openssh complementary packages
    applied 23557350608... rootfs-postcommands.bbclass: avoid moving ssh host keys if etc is writable
    applied 2386037b334... cairo: Adapt the license information based on what is being built
    applied 26dbc1f641a... rootfs.py: dont try to list installed packages for baremetal images
    applied 5ae57d4c9b1... externalsrc: Don't wipe out src dir when EXPORT_FUNCTIONS is used.
    applied baae7384098... oeqa: qemurunner: Report UNIX Epoch timestamp on login
    applied a5eeb959bf0... runqemu: display host uptime when starting
    applied 040e3372ae6... poky.conf: add ubuntu-22.04 to tested distros
    applied c1989b6dfbb... poky.conf: bump version for 4.0.4
    applied 32ca0ff8fa6... system-requirements.rst: Add Ubuntu 22.04 to list of supported distros
    applied c83b189ceee... systemd: Fix unwritable /var/lock when no sysvinit handling
    applied e2d34871f31... systemd: Add 'no-dns-fallback' PACKAGECONFIG option
    applied ff64f3557ee... lighttpd: upgrade 1.4.64 -> 1.4.65
    applied 1fb96d590d1... lighttpd: upgrade 1.4.65 -> 1.4.66
    applied d64bef1c7d7... vim: Upgrade 9.0.0341 -> 9.0.0453
    applied 4766aaa5289... build-appliance-image: Update to kirkstone head revision
    applied b19e6f936f9... go: fix CVE-2022-27664
    applied b7925d6994d... inetutils: fix CVE-2022-39028 - remote DoS vulnerability in inetutils-telnetd
    applied 7935b3f5a19... binutils: fix CVE-2022-38126
    applied 8f99699281b... expat: upgrade 2.4.7 -> 2.4.8
    applied f6e97468993... expat: upgrade 2.4.8 -> 2.4.9
    applied 758a8759325... glibc: stable 2.35 branch updates.
    applied 5059b26559f... libpng: upgrade 1.6.37 -> 1.6.38
    applied f160f3e7f34... vim: Upgrade 9.0.453 -> 9.0.541
    applied c3047eb4c7f... linux-yocto/5.10: update to v5.10.141
    applied 5fce24b8400... linux-yocto/5.10: update to v5.10.143
    applied 6a25979bccd... linux-yocto/5.15: update to v5.15.63
    applied 7e32ade9e0a... linux-yocto/5.15: update to v5.15.65
    applied 6f35f475643... linux-yocto/5.15: update to v5.15.68
    applied 49f308a4144... linux-yocto/5.15: cfg: fix ACPI warnings for -tiny
    applied d696edd8d12... kernel-yocto: allow patch author date to be commit date
    applied 7d49ec7abeb... kern-tools: fix queue processing in relative TOPDIR configurations
    applied 8ab37a166f1... kern-tools: allow 'y' or 'm' to avoid config audit warnings
    applied d63a0167489... perf: Fix for recent kernel upgrades
    applied 2be6d5c029e... linux-firmware: upgrade 20220708 -> 20220913
    applied 41b7466e6fd... linux-firmware: package new Qualcomm firmware
    applied ae4ff6139ad... tzdata: Update from 2022b to 2022c
    applied b3fd3f600d2... u-boot: switch from append to += in SRC_URI
    applied 47f8f11dae2... glibc-tests: use += instead of :append
    applied 74c82513937... go-native: switch from SRC_URI:append to SRC_URI +=
    applied 3842e222e9b... python3-rfc3986-validator: switch from SRC_URI:append to SRC_URI +=
    applied 8fc71a7603f... linux-libc-headers: switch from SRC_URI:append to SRC_URI +=
    applied 27086f89c81... Revert "gcc-cross-canadian: Add symlink to real-ld alongside other symlinks"
    applied 864e65f0f1a... gcc-cross-canadian: add default plugin linker
    applied 5385ece02d6... ltp: Fix pread02 case trigger the glibc overflow detection
    applied 1e779dbf2a6... gcc: add arm-v9 support
    applied 5fd12627d02... tune-neoversen2: support tune-neoversen2 base on armv9a
    applied 18fab7402ad... oeqa/runtime/dnf: fix typo
    applied e81e703fb6f... busybox: add devmem 128-bit support
    applied 4837160315b... poky.yaml.in: update version requirements
    applied c615d00a361... migration-guides: add 4.0.4 release notes
    applied 401ced26713... binutils : Fix CVE-2022-38127
    applied 8b6a66b029e... vim: Upgrade 9.0.0541 -> 9.0.0598
    applied 4ad354b9f66... webkitgtk: Upgrade to 2.36.6 minor update
    applied 1367c472dbd... webkitgtk: Update to 2.36.7
    applied 050f24e279f... rsync: update 3.2.3 -> 3.2.4
    applied f7bab6a01a9... rsync: update 3.2.4 -> 3.2.5
    applied 2c28c2bd4f9... rpm: update 4.17.0 -> 4.17.1
    applied 1a0d480ec2a... rpm: Remove -Wimplicit-function-declaration warnings
    applied 735ce41e460... bind: upgrade 9.18.5 -> 9.18.6
    applied 50ad64b4d53... bind: upgrade 9.18.6 -> 9.18.7
    applied 156202f3322... tzdata: update to 2022d
    applied 6366d8b2f32... lttng-tools: Disable on qemuriscv32
    applied a0b0b25a82e... create-pull-request: don't switch the git remote protocol to git://
    applied e0e7f36ce50... stress-cpu: disable float128 math on powerpc64 to avoid SIGILL
    applied b53a665beba... lttng-tools: Disable on riscv32
    applied d848c5d6aa2... glibc-locale: explicitly remove empty dirs in ${libdir}
    applied 697d4abaf36... coreutils: add openssl PACKAGECONFIG
    applied 77dd7275490... bitbake: runqueue: Ensure deferred tasks are sorted by multiconfig
    applied 6d753d6cbea... bitbake: runqueue: Improve deadlock warning messages
    applied c4745d9c7d1... bitbake: runqueue: Drop deadlock breaking force fail
    applied ace871c1997... bitbake: siggen: Fix insufficent entropy in sigtask file names
    applied 0ac71c5480e... bitbake: bitbake: Add copyright headers where missing
    applied 4b9ac6d5aa9... bitbake: Fix npm to use https rather than http
    applied 189a6d452e3... bitbake: gitsm: Error out if submodule refers to parent repo
    applied 67e4012e626... bitbake: asyncrpc/client: Fix unix domain socket chdir race issues
    applied eaf8ce9d39a... dev-manual: fix reference to BitBake user manual
meta-raspberrypi 0135a02ea5 -> dacad9302a:
    applied fdf82524407... rpi-cmdline: do_compile: Use pure Python syntax to get `CMDLINE`
    applied dacad9302a9... raspberrypi-firmware: Update to 20220830 snapshot
meta-openembedded acbe748798 -> 744a4b6eda:
    applied d15e41f86c5... xrdp: Fix buildpaths warning.
    applied 3a6f77e5166... audit: Upgrade to 3.0.8 and fix build with linux 5.17+
    applied 0609aa408b1... fuse3: support ptest
    applied acdf9bafb0c... fuse3: fix ptest test_passthrough_hp failure
    applied 88aa77cc25a... libipc-signal-perl: Fix LICENSE string
    applied 55e15e8e1da... libdigest-hmac-perl: Fix LICENSE string
    applied aa2e9ba1036... libio-socket-ssl-perl: Fix LICENSE string
    applied 2c68902d19a... libdigest-sha1-perl: Fix LICENSE string
    applied 93c5e37e84e... libmime-types-perl: Fix LICENSE string
    applied eab9d17e5dd... libauthen-sasl-perl: Fix LICENSE string
    applied 7e3599795a4... libnet-ldap-perl: Fix LICENSE string
    applied d933c7242c5... libxml-libxml-perl: Fix LICENSE string
    applied 7f3c8c3a613... libnet-telnet-perl: Fix LICENSE string
    applied caa117e5ccd... libproc-waitstat-perl: Fix LICENSE string
    applied 8f96c05f6d8... lmdb: only set SONAME on the shared library
    applied 035d9c61e81... nodejs-oe-cache-native: initial checkin
    applied 4d804bdf92f... wireguard-module: 1.0.20210219 -> 1.0.20220627
    applied d230d1178f2... wireguard-tools: Add a new package for wg-quick
    applied 9f1013ba455... ntpsec: Add -D_GNU_SOURCE and fix building with devtool
    applied 09acaf6b084... gd: Fix build with clang-15
    applied 8e8f36ef97b... safec: Remove unused variable 'len'
    applied 3cd6cc5dec3... php: upgrade 8.1.8 -> 8.1.9
    applied 02f2e6d762b... libldb: upgrade 2.3.3 -> 2.3.4
    applied b19f3f8c40d... samba: upgrade 4.14.13 -> 4.14.14
    applied 13f1e688421... samba: fix buildpaths issue
    applied 05dcac98473... postgresql: make sure pam conf installed when pam enabled
    applied 8c62aaa67ec... php: upgrade 8.1.9 -> 8.1.10
    applied 73e66e5ea38... postgresql: upgrade 14.4 -> 14.5
    applied 088eaf9ea97... postgreql: Fix pg_config not working after buildpaths patch
    applied 7eff264695d... audit: Revert the tweak done in configure step in do_install
    applied c5b5f631fc4... lmdb: Don't inherit base
    applied fc9c8a3332e... frr: Security fix CVE-2022-37035
    applied de2bbc5ef44... libcec: fix runtime dependencies for ${PN}-examples
    applied bd2d8fba766... minicoredumper: retry elf parsing as long as needed
    applied 3423bc2b37b... wireshark: CVE-2022-3190 Infinite loop in legacy style dissector
    applied 87134241d2a... dnsmasq: upgrade 2.86 -> 2.87
    applied 4d8ce5dfebb... libsdl: add CVE-2019-14906 to allowlist
    applied 0b0086ca9ac... polkit: refresh patch
    applied 9702cc9ba38... net-snmp: upgrade 5.9.1 -> 5.9.3
    applied 6b7c2efd681... open-vm-tools: Security fix CVE-2022-31676
    applied a7b999dba00... tcpreplay: upgrade 4.4.1 -> 4.4.2
    applied 744a4b6eda8... frr: Security fix CVE-2022-37032

openbmc-subtree update -c kirkstone.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --shortlog
