### PR TITLE
subtree update: 0999122bfe -> 975a06f9a4

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,19 +2,19 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 13199c55c013c6f303258bf9a32d289211fe6a5c
+last_revision = 14c7e5b336f3d38a30eaa3a1241df03dd3021ccc
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 6529e5f9630a0879b7735bf867e2a27cee717c57
+last_revision = 8073ec2275c170d2e1bdace3eb1a99e76a851b6e
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = fc5f80a47ed7761509ac0700c81581c97dfe135a
+last_revision = 722c51647c75d63e8c6c53ee214c4e3f0a263ed2
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -26,5 +26,5 @@ last_revision = e8e731818928fcc822688a53d244a98ef5f02488
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 3e5faccfaf50fee0ba8f6eef6c9bf458137d06d2
+last_revision = 95c802b0be3b21a492df910fc75bead6784b3347
 


### PR DESCRIPTION
poky 3e5faccfaf -> 95c802b0be:
    applied 3e78c41c225... ref-manual/variables.rst: clarify sentence
    applied 83495559d90... migration-general: add section on using buildhistory
    applied 500d5bc5c9e... ref-manual: add DISABLE_STATIC
    applied 8ba77dd4034... ref-manual: expand documentation on image-buildinfo class
    applied 72b7a677433... ref-manual: add WATCHDOG_TIMEOUT to variable glossary
    applied 98893c4ddf5... ref-manual: correct default for BUILDHISTORY_COMMIT
    applied e6fb7f27f67... ref-manual: document new github-releases class
    applied 32ba43072b6... ref-manual: add a note to ssh-server-dropbear feature
    applied 3dbc1e83f26... ref-manual: update buildpaths QA check documentation
    applied 776ec078c4c... ref-manual: add UBOOT_MKIMAGE_KERNEL_TYPE
    applied c81fd60784d... ref-manual: add DEV_PKG_DEPENDENCY
    applied 9dd5d8d1adf... ref-manual: add SDK_TOOLCHAIN_LANGS
    applied af3beeecfbc... ref-manual: add pypi class
    applied f4d633a7c28... ref-manual: update pypi documentation for CVE_PRODUCT default in 4.1
    applied 81f311e3476... ref-manual: add CVE_CHECK_SHOW_WARNINGS
    applied 256dcac518d... ref-manual: add FIT_PAD_ALG
    applied 260d09106f6... ref-manual: add CVE_DB_UPDATE_INTERVAL
    applied a9a00a60041... ref-manual: add KERNEL_DEPLOY_DEPEND
    applied 335a230a351... ref-manual: add MOUNT_BASE variable
    applied c29eb10e318... ref-manual: remove reference to testimage-auto class
    applied b1d17778658... Update documentation for classes split
    applied 1bdb6457dda... ref-manual: complementary package installation recommends
    applied 7bf7115afa0... ref-manual: remove reference to largefile in DISTRO_FEATURES
    applied 1568e8a1f6e... ref-manual: add missing features
    applied 4ce28144c5e... ref-manual: add serial-autologin-root to IMAGE_FEATURES documentation
    applied d73883dfefd... ref-manual: add previous overlayfs-etc variables
    applied 0aa40dc125a... ref-manual: add OVERLAYFS_ETC_EXPOSE_LOWER
    applied 7a417c450ef... ref-manual: add WIRELESS_DAEMON
    applied 9e56bf9d8e8... ref-manual: add section for create-spdx class
    applied 01372ac01cf... ref-manual: add overlayfs class variables
    applied ae9eb5684a3... ref-manual: add OVERLAYFS_QA_SKIP
    applied a0fbaf259cc... Add 4.1 migration guide & release notes
    applied 1cba9417262... test-manual: fix typo in machine name
    applied 051e8d83bb2... ref-manual: faq.rst: reorganize into subsections, contents at top
    applied 736135a53de... migration-guides: use contributor real name
    applied ff39a784b42... sdk-manual: correct the bitbake target for a unified sysroot build
    applied 2f9472efbc3... migration-guides: add known issues for 4.1
    applied 43cc9a16c12... migration-guides/release-notes-4.1.rst: add more known issues
    applied d09132d1303... manuals: fix misc typos
    applied f4fe7cdaa7f... migration-guides: use contributor real name
    applied 95c802b0be3... release-notes-4.1.rst remove bitbake-layers subcommand argument
meta-arm 13199c55c0 -> 14c7e5b336:
    applied c3ada285de3... arm-bsp/optee: add log handler
    applied 63cf57290be... arm-bsp/trusted-services: support for libmetal and openamp
    applied c7660b3548a... arm-bsp/linux: add kernel file search path for N1SDP
    applied 75a8c07a636... arm-bsp: remove TC0
    applied c9874bebc7a... arm-bsp/scp-firmware: remove TC0 patches
    applied 75b883c3632... arm/fvp-tc0: remove Total Compute 2020 FVP
    applied f83c5ad19e2... CI: track langdale branch
    applied 14c7e5b336f... arm-bsp/u-boot: corstone1000: support 32bit ffa direct messaging
meta-openembedded 6529e5f963 -> 8073ec2275:
    applied c8d9407eec2... redis: upgrade 7.0.4 to 7.0.5
    applied 5b8ae45ee56... remmina: Update to 1.4.27
    applied 442909de282... v4l-utils: Support building without NLS
    applied feacae5c38b... onboard: remove
    applied 2c71d7f0986... pipewire: upgrade 0.3.57 -> 0.3.59
    applied 72273d28e21... wireplumber: upgrade 0.4.11 -> 0.4.12
    applied 349c26d8779... crucible: Add recipe
    applied 80b68df7091... conntrack-tools: Upgrade 1.4.6 -> 1.4.7
    applied 4d8d56d0e7d... conntrack-tools: Add PACKAGECONFIGs for build options
    applied 4a0e41431e3... conntrack-tools: Use canonical shell spacing
    applied 0c1f379f424... md4c: added md4c lib
    applied 528d29b4a90... double-conversion: added double-conversion lib
    applied e14f87b8129... python3-imageio: Upgrade 2.22.1 -> 2.22.2
    applied 4206fbd4aa2... python3-distro: Upgrade 1.7.0 -> 1.8.0
    applied 3ba38a79f76... uriparser: Upgrade 0.9.6 -> 0.9.7
    applied 3ab22400d18... abseil-cpp: Upgrade to head on 2022-10-14
    applied 0afaceb22ad... broadcom-bt-firmware: upgrade
    applied 77946256275... cppzmq: upgrade 4.8.1 -> 4.9.0
    applied c43afad630e... ctags: upgrade 5.9.20221002.0 -> 5.9.20221009.0
    applied c57b93b6a6b... debootstrap: upgrade 1.0.127 -> 1.0.128
    applied f71bd5172a1... freerdp: upgrade 2.8.0 -> 2.8.1
    applied d067d2e48e5... gst-editing-services: upgrade 1.20.3 -> 1.20.4
    applied c2b5393b55e... libwacom: upgrade 2.4.0 -> 2.5.0
    applied c6fddf41de2... nbdkit: upgrade 1.33.1 -> 1.33.2
    applied 833c5f30ffd... xfstests: upgrade 2022.09.25 -> 2022.10.09
    applied e5ecbd204b6... blueman: upgrade 2.3.2 -> 2.3.4
    applied 5b6ccc07b5d... cli11: upgrade 2.2.0 -> 2.3.0
    applied 1e5473508af... tesseract: upgrade 4.1.3 -> 5.2.0
    applied 034fbd64b13... python3-absl: upgrade 1.2.0 -> 1.3.0
    applied 369ab518e1c... python3-gevent: upgrade 22.8.0 -> 22.10.1
    applied 7126279eb47... python3-google-api-core: upgrade 2.10.1 -> 2.10.2
    applied fbea86469fa... python3-google-api-python-client: upgrade 2.62.0 -> 2.64.0
    applied 93e9fe9f7a4... python3-google-auth: upgrade 2.11.1 -> 2.12.0
    applied 36dc55c4274... python3-pymodbus: upgrade 2.5.3 -> 3.0.0
    applied 8308650fdd2... python3-pywbem: upgrade 1.4.1 -> 1.5.0
    applied 41db40c805b... python3-stevedore: upgrade 4.0.0 -> 4.0.1
    applied bfa88927638... yelp: upgrade 42.1 -> 42.2
    applied 6a83049859d... tio: upgrade 2.0 -> 2.1
    applied a758d95ebbb... python3-zopeinterface: upgrade 5.4.0 -> 5.5.0
    applied aca28022cc3... unbound: upgrade 1.16.3 -> 1.17.0
    applied 36f92899a6a... Add condition for libusbgx-examples
    applied 050b5414b30... xfce4-settings: upgrade 4.16.2 -> 4.16.3
    applied 923635099dc... grpc: Update to 1.50.x release
    applied 8073ec2275c... Add recipe for Perfetto
meta-raspberrypi fc5f80a47e -> 722c51647c:
    applied 722c51647c7... rpi-base.inc: handle empty/undefined KERNEL_DEVICETREE

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
