### PR TITLE
langdale: subtree update: 5641269ed7 -> f241bb5774

### DIFF
--- a/langdale.conf
+++ b/langdale.conf
@@ -2,13 +2,13 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = langdale
-last_revision = 14c7e5b336f3d38a30eaa3a1241df03dd3021ccc
+last_revision = 4ee457693ed01c1c22e4244ad930732128511c2b
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = langdale
-last_revision = 8073ec2275c170d2e1bdace3eb1a99e76a851b6e
+last_revision = c5668905a6d8a78fb72c2cbf8b20e91e686ceb86
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
@@ -20,11 +20,11 @@ last_revision = 722c51647c75d63e8c6c53ee214c4e3f0a263ed2
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = langdale
-last_revision = e8e731818928fcc822688a53d244a98ef5f02488
+last_revision = 2aa48e6f4e519abc7d6bd56da2c067309a303e80
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = langdale
-last_revision = 95c802b0be3b21a492df910fc75bead6784b3347
+last_revision = 6b9db5a99bf0fab47219d4648f4663c4397ac87f
 


### PR DESCRIPTION
meta-arm 14c7e5b336 -> 4ee457693e:
    skipped 1935f51d0ff... CI: fix to langdale
    skipped be90d2e4b00... arm-bsp/u-boot: corstone1000: support 32bit ffa direct messaging
    applied a42ee82eda2... arm/trusted-services: port crypto config
    applied 0245e6609c7... arm/hafnium: add missing Upstream-Status
    applied 062aef06c77... arm-bsp/hafnium: add missing Upstream-Status
    applied bd010531215... arm-bsp/linux-arm64-ack: fix malformed Upstream-Status tag
    applied 0a7c6ae7e13... runfvp: corstone1000: add mmc card configuration
    applied 950372e99dc... meta-arm-bsp/doc: add readthedocs for corstone1000
    applied 72f0580f70e... CI: add documentation job
    applied e4a58093737... arm-bsp/corstone1000: apply ts patch to psa crypto api test
    applied b4dfea8e287... Revert "arm-bsp/trusted-firmware-m: corstone1000: secure debug code checkout from yocto"
    applied bb02720fd7b... Revert "arm-bsp/trusted-firmware-m: corstone1000: bump tfm SHA"
    applied 9e17830b846... arm-bsp/trusted-firmware-m: corstone1000 support FMP image info
    applied 952dee0de9b... arm-bsp/trusted-service: corstone1000: esrt support
    applied d3541b1e296... CI: Remove host bitbake variables
    applied f312adf47b4... arm-bsp/corstone1000: add msd configs for fvp
    applied 46e8092b6b7... kas: corstone1000: set branches to langdale
    applied 4ee457693ed... CI: track meta-openembedded's langdale branch
meta-security e8e7318189 -> 2aa48e6f4e:
    applied d7d3056ed7a... kas-security-base.yml: make work again
    applied 6bc02ba9895... tpm2-openssl: update to 1.1.1
    applied 2aa48e6f4e5... Update PARSEC recipe to latest v1.1.0 release
meta-openembedded 8073ec2275 -> c5668905a6:
    applied 19963d1f5fc... uutils-coreutils: upgrade 0.0.15 -> 0.0.16
    applied 3eaf01fcd4f... jq: improve ptest and disable valgrind by default
    applied a067e1ba946... perfetto: build libperfetto
    applied 90acb408914... vboxguestdrivers: upgrade 6.1.38 -> 7.0.0
    applied dd5226bed9c... postfix: Upgrade to 3.7.3
    applied 30903dd79e0... msktutil: Add recipe
    applied bd8defdcd8b... Add recipe for python3-pytest-json-report
    applied cfac82c560e... syzkaller: add recipe and selftest for syzkaller fuzzing
    applied 51a12d6e8e5... audit: Fix compile error for audit_2.8.5
    applied ded3e642e3d... protobuf: Enable protoc binary in nativesdk
    applied c5668905a6d... meta-openemnedded: Add myself as langdale maintainer
poky 95c802b0be -> 6b9db5a99b:
    applied 3a3a9728ec1e... manuals: updates for building on Windows (WSL 2)
    applied e3d914b343e2... ref-manual: classes.rst: add links to all references to a class
    applied 56e3989b898f... migration-guides/release-notes-4.1.rst: update Repositories / Downloads
    applied 641c4d3a1c37... docs: add support for langdale (4.1) release
    applied 9c8907cf8842... poky.conf: remove Ubuntu 21.10
    applied dce301921264... install-buildtools: support buildtools-make-tarball and update to 4.1
    applied c1304a0231fd... populate_sdk_base: ensure ptest-pkgs pulls in ptest-runner
    applied 4fd15f4e3ad5... scripts/oe-check-sstate: cleanup
    applied 7e4b96e911f6... scripts/oe-check-sstate: force build to run for all targets, specifically populate_sysroot
    applied 378f67bd825b... externalsrc: move back to classes
    applied 5052a071e5b1... dropbear: add pam to PACKAGECONFIG
    applied e1053b622c0f... linux-yocto: add efi entry for machine features
    applied bd22878de384... psplash: add psplash-default in rdepends
    applied 1582d7d3e9ea... opkg-utils: use a git clone, not a dynamic snapshot
    applied 5f6076803027... insane.bbclass: Allow hashlib version that only accepts on parameter
    applied 79af23dc5ef1... oe/packagemanager/rpm: don't leak file objects
    applied 691fb631a2b3... u-boot: Remove duplicate inherit of cml1
    applied 6ba44ce2eef2... u-boot: Add savedefconfig task
    applied dc0af3be0f54... perf: Depend on native setuptools3
    applied 5c8103695de8... gcc: Allow -Wno-error=poison-system-directories to take effect
    applied 988a27974f06... own-mirrors: add crate
    applied c34d00cd1b4c... zlib: use .gz archive and set a PREMIRROR
    applied df88a6b20a05... bluez5: add dbus to RDEPENDS
    applied a5e4b5d175d5... openssl: export necessary env vars in SDK
    applied ee9db0d1fdb1... glib-2.0: fix rare GFileInfo test case failure
    applied 180de83da8ac... cve-update-db-native: add timeout to urlopen() calls
    applied 5b62ac0a3c77... gnutls: Unified package names to lower-case
    applied 7deed5f7b1a8... lighttpd: fix CVE-2022-41556
    applied 5724847549ba... migration-guides/release-notes-4.1.rst: update Repositories / Downloads
    applied b6d633e7f333... openssl: Fix SSL_CERT_FILE to match ca-certs location
    applied 7aa3ed5c37f3... bitbake: bitbake: user-manual: inform about spaces in :remove
    applied ec08faf2e459... bitbake: utils/ply: Update md5 to better report errors with hashlib
    applied c58059d282fe... bitbake: doc: bitbake-user-manual: expand description of BB_PRESSURE_MAX variables
    applied 6672cbe6701a... bitbake: tests: bb.tests.fetch.URLHandle: add 2 new tests
    applied 6b9db5a99bf0... bitbake: tests/fetch: Allow handling of a file:// url within a submodule

openbmc-subtree update -c langdale.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
