### PR TITLE
subtree update: 5641269ed7 -> 2390b1b629

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 14c7e5b336f3d38a30eaa3a1241df03dd3021ccc
+last_revision = 3b7347cd67eb127a4e5757f1bd6772f83ef04a59
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 8073ec2275c170d2e1bdace3eb1a99e76a851b6e
+last_revision = 6ebff843cce0a66a7749e048f280bb9cfdca5946
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 722c51647c75d63e8c6c53ee214c4e3f0a263ed2
+last_revision = a305f4804b167a2849223468fd48089c5e885221
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = e8e731818928fcc822688a53d244a98ef5f02488
+last_revision = 2aa48e6f4e519abc7d6bd56da2c067309a303e80
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 95c802b0be3b21a492df910fc75bead6784b3347
+last_revision = 482c493cf681121fb041f98066a42af14145ff9e
 


### PR DESCRIPTION
meta-arm 14c7e5b336 -> 3b7347cd67:
    applied 242023336f03... arm/trusted-services: port crypto config
    applied 7730ae58ac25... arm/hafnium: add missing Upstream-Status
    applied 3e7dc144b126... arm-bsp/hafnium: add missing Upstream-Status
    applied a27735f0d63f... arm-bsp/linux-arm64-ack: fix malformed Upstream-Status tag
    applied a8075e147151... runfvp: corstone1000: add mmc card configuration
    applied ba196a90a73c... meta-arm-bsp/doc: add readthedocs for corstone1000
    applied 2fffdd9234c9... CI: add documentation job
    applied ba41fd5e1e37... arm-bsp/corstone1000: apply ts patch to psa crypto api test
    applied 8bde04ca2316... Revert "arm-bsp/trusted-firmware-m: corstone1000: secure debug code checkout from yocto"
    applied dc4a702aaff9... Revert "arm-bsp/trusted-firmware-m: corstone1000: bump tfm SHA"
    applied bcba4a6c5f4c... arm-bsp/trusted-firmware-m: corstone1000 support FMP image info
    applied 9771beb10379... arm-bsp/trusted-service: corstone1000: esrt support
    applied d1666f4da2c5... CI: Remove host bitbake variables
    applied 30e78c055265... arm-bsp/optee: register DRAM1 for N1SDP target
    applied 0e7c1bb30e62... arm-bsp:optee: enable optee test for N1SDP target
    applied 50cd8f9c9fa3... arm-bsp/corstone1000: add msd configs for fvp
    applied 8d7f3c03ef70... arm: add Mickledore to layer compat string
    applied 518294d51896... optee-ftpm/optee-os: add missing space in EXTRA_OEMAKE
    applied 3080a94bde5a... optee-os-ts: avoid using escape chars in EXTRA_OEMAKE
    applied 7683a6d1d105... CI: track meta-openembedded's langdale branch
    applied 49b23ff619eb... CI: Add packages for opencsd and gator-daemon to base build
    applied 75c252049c55... CI: add common fvp yml file
    applied 59c3e948e874... arm/opencsd: update to version 1.3.1
    applied 3b7347cd67eb... arm/gator-daemon: update to v7.8.0
meta-raspberrypi 722c51647c -> a305f4804b:
    applied a305f4804b16... libcamera: rename bbappend to match any version
meta-openembedded 8073ec2275 -> 6ebff843cc:
    applied 19963d1f5fc9... uutils-coreutils: upgrade 0.0.15 -> 0.0.16
    applied 3eaf01fcd4fe... jq: improve ptest and disable valgrind by default
    applied a067e1ba9469... perfetto: build libperfetto
    applied 90acb408914a... vboxguestdrivers: upgrade 6.1.38 -> 7.0.0
    applied dd5226bed9cc... postfix: Upgrade to 3.7.3
    applied 30903dd79e0e... msktutil: Add recipe
    applied bd8defdcd8b6... Add recipe for python3-pytest-json-report
    applied cfac82c560e5... syzkaller: add recipe and selftest for syzkaller fuzzing
    applied 51a12d6e8e5c... audit: Fix compile error for audit_2.8.5
    applied ded3e642e3da... protobuf: Enable protoc binary in nativesdk
    applied c782674d3f45... lldpd: Upgrade 1.0.14 -> 1.0.15
    applied 1032bce77885... libcamera: upgrade -> 0.0.1
    applied 2ab46bac63c3... fwupd: Fix plugin_gpio PACKAGECONFIG
    applied 8e64d8f7afa2... tcpslice: upgrade 1.5 -> 1.6
    applied 8dd9faa5c6f2... bats: upgrade 1.8.0 -> 1.8.2
    applied 443259d5db79... ctags: upgrade 5.9.20221009.0 -> 5.9.20221016.0
    applied 6a0ea55c1aa0... fvwm: upgrade 2.6.9 -> 2.7.0
    applied 09dc7c780677... libglvnd: add new recipe libglvnd v1.5.0
    applied 9712b6ea416f... makedumpfile: upgrade 1.7.1 -> 1.7.2
    applied cc532b9d4e03... sanlock: upgrade 3.8.4 -> 3.8.5
    applied bebe7f7963d8... tio: upgrade 2.1 -> 2.2
    applied 5bdd2eb08be0... python3-astroid: upgrade 2.12.11 -> 2.12.12
    applied 577bc31a0a42... python3-charset-normalizer: upgrade 2.1.1 -> 3.0.0
    applied a25ba3ae919f... python3-google-api-python-client: upgrade 2.64.0 -> 2.65.0
    applied 0789ccf0cb8a... python3-google-auth: upgrade 2.12.0 -> 2.13.0
    applied 52cae04d99f4... python3-grpcio-tools: upgrade 1.49.1 -> 1.50.0
    applied 8eea58d6361b... python3-grpcio: upgrade 1.49.1 -> 1.50.0
    applied e7c7c60edde1... python3-huey: upgrade 2.4.3 -> 2.4.4
    applied da032964190c... python3-incremental: upgrade 21.3.0 -> 22.10.0
    applied 2f15b2e4ba9d... python3-luma-core: upgrade 2.3.1 -> 2.4.0
    applied eb6ccb958e48... python3-oauthlib: upgrade 3.2.1 -> 3.2.2
    applied 4fa639ee1b80... python3-pandas: upgrade 1.5.0 -> 1.5.1
    applied bce0c9103171... python3-pastedeploy: upgrade 2.1.1 -> 3.0.1
    applied 3b17c8b52086... python3-pika: upgrade 1.3.0 -> 1.3.1
    applied 7a439be8b0d1... python3-portalocker: upgrade 2.5.1 -> 2.6.0
    applied 2f52d3349531... python3-protobuf: upgrade 4.21.7 -> 4.21.8
    applied 7e53ce578f95... python3-pyjwt: upgrade 2.5.0 -> 2.6.0
    applied d8706e5b339c... python3-pymongo: upgrade 4.2.0 -> 4.3.2
    applied 1605c2bf33f0... python3-pywbemtools: upgrade 1.0.0 -> 1.0.1
    applied 528bc40faee5... python3-robotframework: upgrade 5.0.1 -> 6.0
    applied 940e750b8267... python3-socketio: upgrade 5.7.1 -> 5.7.2
    applied c6ef4d982834... python3-sqlalchemy: upgrade 1.4.41 -> 1.4.42
    applied 18db04555464... python3-stevedore: upgrade 4.0.1 -> 4.1.0
    applied fb1c56aa59f8... python3-xxhash: upgrade 3.0.0 -> 3.1.0
    applied 49aed62f347c... python3-zeroconf: upgrade 0.39.1 -> 0.39.2
    applied aa1523d9df7f... python3-cheetah: Upgrade 3.2.6 -> 3.2.6.post1
    applied facbd80e82f4... python3-dill: Upgrade 0.3.5.1 -> 0.3.6
    applied 6b4f2590d82d... python3-pythonping: Upgrade 1.1.3 -> 1.1.4
    applied 06f4c93a06cc... python3-colorama: Upgrade 0.4.5 -> 0.4.6
    applied 0ff42a7e9f4e... python3-pint: Upgrade 0.19.2 -> 0.20
    applied 4dc1c6e16b31... sip3: remove the recipe
    applied f2eff0296211... python3-wxgtk4: skip the recipe
    applied aa652dbed9b5... python3-yappi: mark as incompatible with python 3.11
    applied 51aea2c8ee71... python3-traitlets: Upgrade 5.4.0 -> 5.5.0
    applied b1a3c0c3c3fb... python3-py-cpuinfo: Upgrade 8.0.0 -> 9.0.0
    applied cca9e65fae35... valijson: use install task from CMakeLists.txt
    applied fe4c5cb10116... nginx: Add ipv6 support
    applied 8210e5904c7c... cpputest: remove dev package dependency
    applied 8c0402f7c471... cpputest: add possibility to build extensions
    applied cb50a9eb7c00... vbxguestdrivers: upgrade 7.0.0 -> 7.0.2
    applied 7056f31fd93a... iniparser: Add native support
    applied 22afd3926453... libzip: Add native support
    applied c6512403d1bc... xf86-video-amdgpu: add new recipe xf86-video-amdgpu
    applied e87a9506f049... android-tools-conf-configfs: Allow handling two or more UDC controllers
    applied 4a2ab98f3944... gtk-vnc: add recipe
    applied fc176683e6f0... libmime-types-perl: upgrade 2.17 -> 2.22
    applied 0b3e25a3c13f... libcompress-raw*-perl: move from libio/compress-*
    applied 74c84f4c1159... libio-compress*-perl: cleanup; fixes
    applied 5c927fc44360... libcompress-raw-*-perl: cleanup; fixes
    applied 3f20244401fe... packagegroup-meta-perl: mv libcompress-raw-*-perl
    applied 8b70c195b3b2... tracker-miners: upgrade 3.2.1 -> 3.4.1
    applied db39f8875f18... tracker: upgrade 3.4.0 -> 3.4.1
    applied a9334a5cba6d... wolfssl: upgrade 5.5.1 -> 5.5.2
    applied e17367495209... cglm: upgrade 0.8.5 -> 0.8.7
    applied e72998c00491... ctags: upgrade 5.9.20221016.0 -> 5.9.20221023.0
    applied aa5ea92a4a61... flatbuffers: upgrade 22.9.29 -> 22.10.26
    applied 30444c8a59f6... function2: upgrade 4.2.1 -> 4.2.2
    applied 0239a702d370... poco: upgrade 1.12.2 -> 1.12.3
    applied 744942c4f584... thingsboard-gateway: upgrade 3.1 -> 3.2
    applied b7033c7ec2ea... jwt-cpp: add recipe
    applied 00895a31a854... spice-gtk: add recipe
    applied 5bff9c42987f... grpc: upgrade 1.50.0 -> 1.50.1
    applied 6ebff843cce0... ipmitool: fix typo in .bb file's comments, using = instead of =?
meta-security e8e7318189 -> 2aa48e6f4e:
    applied d7d3056ed7a2... kas-security-base.yml: make work again
    applied 6bc02ba9895e... tpm2-openssl: update to 1.1.1
    applied 2aa48e6f4e51... Update PARSEC recipe to latest v1.1.0 release
poky 95c802b0be -> 482c493cf6:
    applied 3a3a9728ec1e... manuals: updates for building on Windows (WSL 2)
    applied e3d914b343e2... ref-manual: classes.rst: add links to all references to a class
    applied 56e3989b898f... migration-guides/release-notes-4.1.rst: update Repositories / Downloads
    applied 641c4d3a1c37... docs: add support for langdale (4.1) release
    applied 9c8907cf8842... poky.conf: remove Ubuntu 21.10
    applied dce301921264... install-buildtools: support buildtools-make-tarball and update to 4.1
    applied c1304a0231fd... populate_sdk_base: ensure ptest-pkgs pulls in ptest-runner
    applied 4fd15f4e3ad5... scripts/oe-check-sstate: cleanup
    applied 7e4b96e911f6... scripts/oe-check-sstate: force build to run for all targets, specifically populate_sysroot
    applied 378f67bd825b... externalsrc: move back to classes
    applied 5052a071e5b1... dropbear: add pam to PACKAGECONFIG
    applied e1053b622c0f... linux-yocto: add efi entry for machine features
    applied bd22878de384... psplash: add psplash-default in rdepends
    applied 1582d7d3e9ea... opkg-utils: use a git clone, not a dynamic snapshot
    applied 5f6076803027... insane.bbclass: Allow hashlib version that only accepts on parameter
    applied 79af23dc5ef1... oe/packagemanager/rpm: don't leak file objects
    applied 691fb631a2b3... u-boot: Remove duplicate inherit of cml1
    applied 6ba44ce2eef2... u-boot: Add savedefconfig task
    applied dc0af3be0f54... perf: Depend on native setuptools3
    applied 5c8103695de8... gcc: Allow -Wno-error=poison-system-directories to take effect
    applied 988a27974f06... own-mirrors: add crate
    applied c34d00cd1b4c... zlib: use .gz archive and set a PREMIRROR
    applied df88a6b20a05... bluez5: add dbus to RDEPENDS
    applied a5e4b5d175d5... openssl: export necessary env vars in SDK
    applied ee9db0d1fdb1... glib-2.0: fix rare GFileInfo test case failure
    applied 180de83da8ac... cve-update-db-native: add timeout to urlopen() calls
    applied 5b62ac0a3c77... gnutls: Unified package names to lower-case
    applied 7deed5f7b1a8... lighttpd: fix CVE-2022-41556
    applied 5724847549ba... migration-guides/release-notes-4.1.rst: update Repositories / Downloads
    applied f21dff5b8932... bitbake: cooker: fix a typo
    applied a09806e9431b... bitbake: runqueue: fix a typo
    applied 472919ff8ff0... meson: make wrapper options sub-command specific
    applied f70cd330e3ae... mesa: only apply patch to fix ALWAYS_INLINE for native
    applied 95cf9e6f2e0e... base-passwd: Update to 3.6.1
    applied 4dc4c214e0dd... vim: Upgrade 9.0.0598 -> 9.0.0614
    applied 3841c39c6111... acpid: upgrade 2.0.33 -> 2.0.34
    applied f19307ef4147... python3-hatchling: upgrade 1.9.0 -> 1.10.0
    applied b5429ef493b2... pango: upgrade 1.50.9 -> 1.50.10
    applied a917f405c7d6... piglit: upgrade to latest revision
    applied 5680ba2ca5c0... lsof: upgrade 4.95.0 -> 4.96.3
    applied 5b0de8447e5a... wic: add UEFI kernel as UEFI stub
    applied 2cd51cfe9989... wic: bootimg-efi: implement --include-path
    applied 2eb933bb8c92... overlayfs: Allow not used mount points
    applied 19165db0c08a... buildtools-tarball: export certificates to python and curl
    applied 59ba302179e1... musl: Upgrade to latest master
    applied 0164f9571915... python3-cryptography: upgrade 37.0.4 -> 38.0.1
    applied d27bd39e96aa... python3-cryptography-vectors: upgrade 37.0.4 -> 38.0.1
    applied 3f4b5228c573... python3-certifi: upgrade 2022.9.14 -> 2022.9.24
    applied 95d115d54bbb... python3-hypothesis: upgrade 6.54.5 -> 6.56.1
    applied 2df5845ee6c5... python3-pyopenssl: upgrade 22.0.0 -> 22.1.0
    applied 85b376ed9957... python3-bcrypt: upgrade 3.2.2 -> 4.0.0
    applied 49c531b9be38... python3-sphinx: upgrade 5.1.1 -> 5.2.3
    applied 61cb04e5afb7... python3-setuptools-rust: upgrade 1.5.1 -> 1.5.2
    applied fc6c0212f6e4... python3-iso8601: upgrade 1.0.2 -> 1.1.0
    applied 4f5841bb000b... python3-poetry-core: upgrade 1.0.8 -> 1.3.2
    applied bbdc56188432... init-system-helpers: upgrade 1.64 -> 1.65.2
    applied 72191b79d219... meson: upgrade 0.63.2 -> 0.63.3
    applied bf2454f9ea97... mtools: upgrade 4.0.40 -> 4.0.41
    applied d2efdea9235f... dbus: upgrade 1.14.0 -> 1.14.4
    applied f6d4779384ff... ifupdown: upgrade 0.8.37 -> 0.8.39
    applied 08d4318e2a28... openssh: upgrade 9.0p1 -> 9.1p1
    applied e5e895670bff... python3-hatchling: upgrade 1.10.0 -> 1.11.0
    applied 05fc042232d5... u-boot: upgrade 2022.07 -> 2022.10
    applied 66cdee57c311... python3-git: upgrade 3.1.27 -> 3.1.28
    applied 9fc46b86db11... python3-importlib-metadata: upgrade 4.12.0 -> 5.0.0
    applied b49764df34f3... qemu-native: Add PACKAGECONFIG option for jack
    applied 694695211fc5... python3-manifest.json: Move urllib to netclient
    applied b1064661ee7f... gnutls: upgrade 3.7.7 -> 3.7.8
    applied b4992b6082d6... gsettings-desktop-schemas: upgrade 42.0 -> 43.0
    applied ad1e179aedff... harfbuzz: upgrade 5.1.0 -> 5.3.0
    applied b158ae32ed83... libcap: upgrade 2.65 -> 2.66
    applied a7873c4f7707... libical: upgrade 3.0.14 -> 3.0.15
    applied 80e7b3d1dcc4... libva: upgrade 2.15.0 -> 2.16.0
    applied a4d438833c96... libva-utils: upgrade 2.15.0 -> 2.16.0
    applied 3736b98be4a1... powertop: upgrade 2.14 -> 2.15
    applied c36b45b2ef11... numactl: upgrade 2.0.15 -> 2.0.16
    applied 2d8c8b418784... python3-pytz: upgrade 2022.2.1 -> 2022.4
    applied a7212a07990d... python3-zipp: upgrade 3.8.1 -> 3.9.0
    applied 76f1478529b7... repo: upgrade 2.29.2 -> 2.29.3
    applied b4b317ae6b1f... sqlite3: upgrade 3.39.3 -> 3.39.4
    applied 764d5105811e... wpebackend-fdo: upgrade 1.12.1 -> 1.14.0
    applied b36d999b7e19... xkeyboard-config: upgrade 2.36 -> 2.37
    applied 239a00322d32... xz: upgrade 5.2.6 -> 5.2.7
    applied 1b04d5f41577... libksba: upgrade 1.6.0 -> 1.6.2
    applied f81b93b13d02... libsdl2: upgrade 2.24.0 -> 2.24.1
    applied bef5a8950d39... libwpe: upgrade 1.12.3 -> 1.14.0
    applied 7256b1877063... lttng-ust: upgrade 2.13.4 -> 2.13.5
    applied 7b3828259c44... linux-yocto-dev: add qemuarm64
    applied 36b9f4f3d06f... wic: implement binary repeatable disk identifiers
    applied 9537b02838c3... buildconf: compare abspath
    applied b72193a602c9... rust: update 1.63.0 -> 1.64.0
    applied 7dc782a8fcc8... go-mod.bbclass: Remove repeated word
    applied 8965c3a1a6a3... btrfs-tools: upgrade 5.19.1 -> 6.0
    applied 607c8f5809cf... zlib: do out-of-tree builds
    applied 92de327c68c0... zlib: upgrade 1.2.12 -> 1.2.13
    applied af4cb167597a... vulkan-samples: add lfs=0 to SRC_URI to avoid git smudge errors in do_unpack
    applied 27e0442d7ba0... linux-firmware: split rtl8761 firmware
    applied d7c69492c187... linux-firmware: package amdgpu firmware
    applied d8a5c6551d3a... xserver-xorg: move some recommended dependencies in required
    applied 10ac1595e12b... mesa: Add native patch via a variable
    applied e6dc71b4135c... grub: disable build on armv7ve/a with hardfp
    applied 4c9b5da26bf5... kern-tools: fix relative path processing
    applied 95a5ca31266b... linux-yocto/5.19: update to v5.19.14
    applied cd31c6b6df86... linux-yocto/5.15: update to v5.15.72
    applied e33892b7adf7... create-spdx: Remove ";name=..." for downloadLocation
    applied 1462ce375eeb... systemd: add systemd-creds and systemd-cryptenroll to systemd-extra-utils
    applied b62f7c24bf28... openssl: CVE-2022-3358 Using a Custom Cipher with NID_undef may lead to NULL encryption
    applied 2f7093d9bacc... wayland-protocols: upgrade 1.26 -> 1.27
    applied 9ba58ee035fa... externalsrc.bbclass: fix git repo detection
    applied 0cc7ac200d8c... runqemu: Fix gl-es argument from causing other arguments to be ignored
    applied 0ee936da2eaf... wic: honor the SOURCE_DATE_EPOCH in case of updated fstab
    applied 8dd2fa2205b9... qemu-helper-native: Re-write bridge helper as C program
    applied 8b2348a75ec3... runqemu: Do not perturb script environment
    applied b3ffb247c74c... externalsrc.bbclass: Remove a trailing slash from ${B}
    applied c43df5b5cc6e... gstreamer1.0-libav: fix errors with ffmpeg 5.x
    applied bf8655e116a9... os-release: replace DISTRO_CODENAME with VERSION_CODENAME
    applied 7d29e797183e... os-release: add HOMEPAGE and link to documentation
    applied 7b73c6d62522... kernel-yocto: improve fatal error messages of symbol_why.py
    applied 1d6722d694db... libx11: apply the fix for CVE-2022-3554
    applied 4c24c17799cd... xserver-xorg: ignore CVE-2022-3553 as it is XQuartz-specific
    applied 262f44fd2877... xserver-xorg: backport fixes for CVE-2022-3550 and CVE-2022-3551
    applied 6100383cc469... git: upgrade 2.37.3 -> 2.38.1
    applied c755c37efbab... uboot-sign: Fix using wrong KEY_REQ_ARGS
    applied 00ce3bb06f0b... kernel: Clear SYSROOT_DIRS instead of replacing sysroot_stage_all
    applied 63b4efbbf459... kernel-fitimage: Use KERNEL_OUTPUT_DIR where appropriate
    applied deb6b92d44bf... uboot-sign: Use bitbake variables directly
    applied 930dc57fc8dc... uboot-sign: Split off kernel-fitimage variables
    applied d6858c9f45d2... u-boot: Rework signing to remove interdependencies
    applied 074245a31288... bitbake: bitbake: user-manual: inform about spaces in :remove
    applied fc6f743c52d5... bitbake: utils/ply: Update md5 to better report errors with hashlib
    applied f67176aadac0... bitbake: doc: bitbake-user-manual: expand description of BB_PRESSURE_MAX variables
    applied cba4d320dc41... bitbake: tests: bb.tests.fetch.URLHandle: add 2 new tests
    applied 6e166954841c... openssl: Fix SSL_CERT_FILE to match ca-certs location
    applied 65779419ad26... bitbake: tests/fetch: Allow handling of a file:// url within a submodule
    applied 635faae28e93... bitbake: bitbake-user-manual: details about variable flags starting with underscore
    applied e06b7828aeea... mesa: update 22.2.0 -> 22.2.2
    applied 38be41a6f8ee... tiff: fix a number of CVEs
    applied 8dc68c2a80c0... qemu: backport the fix for CVE-2022-3165
    applied 6608c076f64e... rust-target-config: match riscv target names with what rust expects
    applied 6bf209947d6a... rust: install rustfmt for riscv32 as well
    applied 75c609f17fac... lighttpd: upgrade 1.4.66 -> 1.4.67
    applied 8219c822a965... kernel-fitimage: mangle slashes to underscores as late as possible
    applied 54fe36f9c2b9... kernel-fitimage: skip FDT section creation for applicable symlinks
    applied 75f448bf0da6... go: add support to build on ppc64le
    applied bb715127cb46... mirrors.bbclass: use shallow tarball for binutils-native
    applied 5c86008856aa... tiff: fix a typo for CVE-2022-2953.patch
    applied 67a48d05cf5b... ref-manual: add wic command bootloader ptable option
    applied 20cf9c46a1ef... ref-manual: add info on buildtools-make-tarball
    applied 8a9ac57515d1... ref-manual: variables.rst: add documentation for CVE_VERSION
    applied 362477c421e8... ref-manual: classes.rst: improve documentation for cve-check.bbclass
    applied aa5fd56b9abf... dev-manual: common-tasks.rst: add regular updates and CVE scans to security best practices
    applied e12050dcadde... dev-manual: common-tasks.rst: refactor and improve "Checking for Vulnerabilities" section
    applied bb3fc03ef167... Documentation/README: formalize guidelines for external link syntax
    applied 4def515eebca... manuals: replace "_" by "__" in external links
    applied 6f4ccc4dad8b... manuals: stop referring to the meta-openembedded repo from GitHub
    applied 50458d923826... manuals: add missing references to SDKMACHINE and SDK_ARCH
    applied b44fbe5b1b42... manuals: use references to the "Build Directory" term
    applied d1cd7dc31c95... bitbake: fetch2/git: don't set core.fsyncobjectfiles=0
    applied bd156c4618ae... cmake-native: Fix host tool contamination
    applied c631d4da7900... unfs3: correct upstream version check
    applied c109408ceb7d... gnu-config: update to latest revision
    applied 507a50cf2917... llvm: update 14.0.6 -> 15.0.1
    applied a78ada8639ea... grep: update 3.7 -> 3.8
    applied 5e21fcd82923... hdparm: update 9.64 -> 9.65
    applied 4515da64cc0d... stress-ng: update 0.14.03 -> 0.14.06
    applied 491c56d06c55... vulkan: update 1.3.216.0 -> 1.3.224.1
    applied 0af6aa91dc45... wayland-utils: update 1.0.0 -> 1.1.0
    applied 17e5b9c79b74... libxft: update 2.3.4 -> 2.3.6
    applied 2730a120bd5c... pinentry: update 1.2.0 -> 1.2.1
    applied 6487b06bd07b... ovmf: upgrade edk2-stable202205 -> edk2-stable202208
    applied 660a2b541c3b... cmake: update 3.24.0 -> 3.24.2
    applied 48c4ac798267... jquery: upgrade 3.6.0 -> 3.6.1
    applied b6ec43fead90... python3-dbus: upgrade 1.2.18 -> 1.3.2
    applied 8d2c351e3e91... python3-hatch-fancy-pypi-readme: add a recipe
    applied cd13328a044a... python3-jsonschema: upgrade 4.9.1 -> 4.16.0
    applied 3cd4053a8de1... shadow: update 4.12.1 -> 4.12.3
    applied f15334e3686d... lttng-modules: upgrade 2.13.4 -> 2.13.5
    applied 830738191b78... libsoup: upgrade 3.0.7 -> 3.2.0
    applied 7fffe9763b53... libxslt: upgrade 1.1.35 -> 1.1.37
    applied 852f802a319e... quilt: backport a patch to address grep 3.8 failures
    applied b06633b6ae91... python3: update 3.10.6 -> 3.11.0
    applied 05de18eae721... sanity: check for GNU tar specifically
    applied d2a483338f68... wic: swap partitions are not added to fstab
    applied 65e3e1917edc... create-spdx.bbclass: remove unused SPDX_INCLUDE_PACKAGED
    applied 756e940f15a6... ethtool: upgrade 5.19 -> 6.0
    applied eff3042f0eb0... iproute2: upgrade 5.19.0 -> 6.0.0
    applied 6ca9f04b8e2c... bitbake: asyncrpc: serv: correct closed client socket detection
    applied 78fd269e6649... bitbake: bitbake: bitbake-layers: checkout layer(s) branch when clone exists
    applied d9e944a0e882... cargo_common.bbclass: Fix typos
    applied 04eee9551573... curl: Update 7.85.0 to 7.86.0
    applied 6a5b4d842889... cargo-update-recipe-crates.bbclass: add a class to generate SRC_URI crate lists from Cargo.lock
    applied 756e28d6c754... python3-bcrypt: convert to use cargo-update-recipe-crates class.
    applied d892f4f385b2... python3-cryptography: convert to cargo-update-recipe-crates class
    applied 8cc50902163a... groff: submit patches upstream
    applied a34778471ff8... tcl: correct patch status
    applied 2ff37912ef23... tcl: correct upstream version check
    applied 46c0699501bc... lttng-tools: submit determinism.patch upstream
    applied 3b8477afb211... cmake: drop qt4 patches
    applied 295b28ceec62... kea: submit patch upstream
    applied a952f1046a49... argp-standalone: replace with a maintained fork
    applied d04fb41efcf2... ovmf: correct patches status
    applied 7084d55748ac... go: submit patch upstream
    applied 8506c36e3a6b... libffi: submit patch upstream
    applied 6851217e310e... vim: upgrade 9.0.0614 -> 9.0.0820
    applied 11ad2553f3fc... expat: upgrade to 2.5.0
    applied f5320f05bd06... go: update 1.19 -> 1.19.2
    applied a501f13c500f... gptfdisk: remove warning message from target system
    applied a2a6fb25e634... openssl: Upgrade 3.0.5 -> 3.0.7
    applied 0a97cbba10a7... python3-mako: upgrade 1.2.2 -> 1.2.3
    applied 4a264f369547... oeqa/target/ssh: add ignore_status argument to run()
    applied 3565ea860a8c... oeqa/runtime/dnf: rewrite test_dnf_installroot_usrmerge
    applied e33afcd0dca5... rust-common.bbclass: use built-in rust targets for -native builds
    applied b0c0783e3113... bc: Add ptest.
    applied b5baa7dc8bd1... oeqa/selftest/archiver: Add multiconfig test for shared recipes
    applied cd2f92ceea9c... archiver: avoid using machine variable as it breaks multiconfig
    applied caff6de42bab... go: update 1.19.2 -> 1.19.3
    applied c6d8d49167f0... rust: submit a rewritten version of crossbeam_atomic.patch upstream
    applied dd7f8502ac82... bluez5: Point hciattach bcm43xx firmware search path to /lib/firmware
    applied c63da33605a0... linux-yocto-dev: add qemuarmv5
    applied 74063b89c20c... python3-bcrypt: upgrade 4.0.0 -> 4.0.1
    applied 716981822b02... python3-cryptography{-vectors}: 38.0.1 -> 38.0.3
    applied a329369174d7... python3-psutil: upgrade 5.9.2 -> 5.9.3
    applied cd17a8ac97c6... python3-pytest: upgrade 7.1.3 -> 7.2.0
    applied 7254fe39ca96... python3-pytest-subtests: upgrade 0.8.0 -> 0.9.0
    applied 5edbb3a5258b... python3-hypothesis: upgrade 6.56.1 -> 6.56.4
    applied 57522528c0a4... python3-more-itertools: upgrade 8.14.0 -> 9.0.0
    applied 9e108095c4c8... python3-pytz: upgrade 2022.4 -> 2022.6
    applied 9d70cb39fbb9... python3-zipp: upgrade 3.9.0 -> 3.10.0
    applied 5c31bd2cff02... python3-sphinx: upgrade 5.2.3 -> 5.3.0
    applied 99350f44b2b2... cargo-update-recipe-crates: small improvements
    applied f64890e1fc0a... patchelf: upgrade 0.15.0 -> 0.16.1
    applied 9a478d8eee0e... lttng-modules: upgrade 2.13.5 -> 2.13.7
    applied a193d691dead... weston: update 10.0.2 -> 11.0.0
    applied 482c493cf681... valgrind: update to 3.20.0

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
