### PR TITLE
subtree update: ec27bf221c -> 9ab011ab57

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,19 +2,19 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 3b7347cd67eb127a4e5757f1bd6772f83ef04a59
+last_revision = d5f132b19920870526c3b03c6a932ebb7949f8c6
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 6ebff843cce0a66a7749e048f280bb9cfdca5946
+last_revision = d04444509a220fcb61496d7e64f3ba09c647543b
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = a305f4804b167a2849223468fd48089c5e885221
+last_revision = 93dadf336ce11e3ed3ba75c7638b57fad60d6fdb
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -26,5 +26,5 @@ last_revision = 2aa48e6f4e519abc7d6bd56da2c067309a303e80
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 482c493cf681121fb041f98066a42af14145ff9e
+last_revision = 44bb88cc869f3b42440d6f7aad000e706b739a2b
 


### PR DESCRIPTION
meta-arm 3b7347cd67 -> d5f132b199:
    applied 8724733e079a... kas: corstone1000: set branches to langdale
    applied 4243e66182ee... arm,arm-bsp/recipes-kernel: don't use PN in arm-ffa-transport.inc
    applied b772d9749625... arm/trusted-services: check before applying patches
    applied 11018cbc35c0... arm-bsp/trusted-services: psa test setup corstone1000
    applied ff583cd9a144... arm-bsp/trusted-firmware-m: adjust ps assets for corstone1000
    applied 24f2eea0a5c7... arm-bsp/trusted-services: add checks for null attributes in smm gateway
    applied 2132c21a87e1... arm-bsp/trusted-services: Fix GetNextVariable max_name_len in smm gateway
    applied 53d592c6de30... arm-bsp/fvp-base: Enable virtio-rng support and unset preferred 5.15 kernel
    applied f6ae857b040f... arm/linux-arm64-ack: fix buildpaths in the perf Python module
    applied d5f68b256d33... arm-bsp/documentation: corstone1000: 2022.11.10 RC: update the user guide
    applied bdf559155ae5... arm-bsp/documentation: corstone1000: 2022.11.10 RC: update the release notes
    applied fcf6f0699c3b... arm-bsp/documentation: corstone1000: 2022.11.10 RC: update the change log
    applied 129dcef079bf... arm/sbsa-acs: update to the latest version
    applied f52d4f63d71e... arm/hafnium: cleanup the patches
    applied c97a9c5b393d... arm/gn: update to the latest SHA
    applied 721bec250d5c... arm/fvp: Join cli arguments in verbose logging
    applied 81e0cf090b6b... arm/lib: Factor out asyncio in FVPRunner
    applied 2265bffdc7ed... arm/lib: Decouple console parsing from the FVPRunner
    applied 79e78fb31d84... arm/oeqa: Log the FVP output in OEFVPSSHTarget
    applied d5f132b19920... runfvp: Fix verbose output when using --console
meta-raspberrypi a305f4804b -> 93dadf336c:
    applied 150d442a9b97... ci: Bump actions/checkout to v3
    applied de9bfd04d540... ci: Fix dco-check job with newer git versions
    applied 93dadf336ce1... raspberrypi4-64: drop DEFAULTTUNE assignment
poky 482c493cf6 -> 44bb88cc86:
    applied d23d41bc25b2... get_module_deps3.py: Check attribute '__file__'
    applied 21b4fba145d1... bind: upgrade 9.18.7 -> 9.18.8
    applied 6fd485e8d47d... libedit: upgrade 20210910-3.1 -> 20221030-3.1
    applied d685ecf9efc9... mtools: upgrade 4.0.41 -> 4.0.42
    applied 109549e5b915... diffstat: upgrade 1.64 -> 1.65
    applied f42c3d428d87... inetutils: upgrade 2.3 -> 2.4
    applied 38835266673f... orc: upgrade 0.4.32 -> 0.4.33
    applied 1d4fdea68aed... socat: upgrade 1.7.4.3 -> 1.7.4.4
    applied 41e47358f81c... libxcrypt: upgrade 4.4.28 -> 4.4.30
    applied de15d93a37a9... python3-typing-extensions: upgrade 4.3.0 -> 4.4.0
    applied 4f82bee54ae5... populate_sdk_base: add zip options
    applied e9f25b761df5... python3-babel: upgrade 2.10.3 -> 2.11.0
    applied 46d594e355ac... python3-hatch-fancy-pypi-readme: upgrade 22.7.0 -> 22.8.0
    applied aeda828e5576... python3-hatchling upgrade: 1.11.0 -> 1.11.1
    applied 95f801de6fc2... python3-jsonschema: upgrade 4.16.0 -> 4.17.0
    applied f2baba898d28... python3-pyrsistent: upgrade 0.18.1 -> 0.19.2
    applied 9bd76cdc2057... python3-numpy: upgrade 1.23.3 -> 1.23.4
    applied 6a723da2813b... python3-sphinx-rtd-theme: upgrade 1.0.0 -> 1.1.0
    applied 9728e5b50c66... python3-pbr: upgrade 5.10.0 -> 5.11.0
    applied 5a2b075fa988... bitbake.conf: Drop export of SOURCE_DATE_EPOCH_FALLBACK
    applied 4065f0d84044... cargo.bbclass: avoid calling which ${RUSTC} with undefined ${RUSTC}
    applied a266da2826a1... libuv: fixup SRC_URI
    applied 8fc8f3839908... python3-manifest.json: Fix re in core
    applied db3731112ded... systemd: Consider PACKAGECONFIG in RRECOMMENDS
    applied 7fa4796eb8b5... kernel.bbclass: Include randstruct seed assets in STAGING_KERNEL_BUILDDIR
    applied 2a9bfc7dc8c4... insane: add codeload.github.com to src-uri-bad check
    applied 4e16d1c1f68f... rust: update 1.64.0 -> 1.65.0
    applied 85649cafff81... webkitgtk: use libsoup-3.0 by default
    applied 64f0faa3940b... epiphany: use libsoup-3.0 by default
    applied e1b27258d5b2... mirrors.bbclass: use shallow tarball for nativesdk-binutils
    applied 7f3e02fe740f... dev-manual: common-tasks.rst: fix typos
    applied d16cdfae31e8... ref-manual: terms.rst: add SBOM and SPDX terms
    applied a6f7c43e9229... ref-manual: variables.rst: document spdx-create class variables
    applied a4dee2338783... dev-manual: common-tasks.rst: add section about SPDX / SBOM generation
    applied eb5ea073a8ce... ref-manual: classes.rst: expand documentation of create-spdx class
    applied 0eae6282163e... ref-manual: terms.rst: add reference to new SBOM/SPDX section in dev manual
    applied 1d2681fa729c... manuals: document "mime-xdg" class and MIME_XDG_PACKAGES
    applied ceb169bd59e1... manuals: remove xterm requirements
    applied 3a7dd1d36891... manuals: add shortcut for Wikipedia links
    applied f494d47e6501... gstreamer1.0-plugins-good: use libsoup-3.0 by default
    applied 4b80c6cdc01e... gcc-shared-source: Fix source date epoch handling
    applied b964727e3a33... gcc-source: Fix gengtypes race
    applied 82d294860b07... gcc-source: Drop gengtype manipulation
    applied 2cdaa164e8b4... gcc-source: Ensure deploy_source_date_epoch sstate hash doesn't change
    applied be91408e1080... wic: make ext2/3/4 images reproducible
    applied f2aff70b0ea4... image_types: Add 7-Zip support in conversion types and commands
    applied da4c2739e41d... man-pages: upgrade 5.13 -> 6.01
    applied 8fbed5abd00f... piglit: upgrade to latest revision
    applied 9c56ef554e5f... lsof: upgrade 4.96.3 -> 4.96.4
    applied b7336ce8cc6b... ffmpeg: upgrade 5.1.1 -> 5.1.2
    applied e6cf85235048... ccache: upgrade 4.6.3 -> 4.7.2
    applied 5a86801bc237... python3-pip: upgrade 22.2.2 -> 22.3
    applied b23531a8c2f7... ltp: upgrade 20220527 -> 20220930
    applied 8ef521c00d38... alsa-utils: upgrade 1.2.7 -> 1.2.8
    applied 60eee6a21355... alsa-ucm-conf: upgrade 1.2.7.2 -> 1.2.8
    applied 610b65cd49e3... libbsd: upgrade 0.11.6 -> 0.11.7
    applied 1752cecae187... libunistring: upgrade 1.0 -> 1.1
    applied b3219ef18146... puzzles: upgrade to latest revision
    applied aa850086a477... libsoup: upgrade 3.2.0 -> 3.2.1
    applied 6a26592f9969... linux-firmware: upgrade 20220913 -> 20221012
    applied 781eeef584b5... python3-git: upgrade 3.1.28 -> 3.1.29
    applied 669cc26c4cbe... xwayland: upgrade 22.1.3 -> 22.1.4
    applied 18e87916c601... strace: upgrade 5.19 -> 6.0
    applied 98b871c9c7b2... python3-dtschema: upgrade 2022.8.3 -> 2022.9
    applied 8b92c482560a... fontconfig: upgrade 2.14.0 -> 2.14.1
    applied 7ad4719b51a9... python3-setuptools: upgrade 65.0.2 -> 65.5.0
    applied a3143c2c12d5... taglib: upgrade 1.12 -> 1.13
    applied eaf1d33a1b75... nghttp2: upgrade 1.49.0 -> 1.50.0
    applied 5f349fa8d852... python3-wheel: upgrade 0.37.1 -> 0.38.0
    applied 55e1e6dd0846... libffi: upgrade 3.4.2 -> 3.4.4
    applied 50dc127c9dfc... libical: upgrade 3.0.15 -> 3.0.16
    applied 794fdb05c465... mtd-utils: upgrade 2.1.4 -> 2.1.5
    applied 278e2dda04f0... repo: upgrade 2.29.3 -> 2.29.5
    applied 9954a1687f45... libidn2: upgrade 2.3.3 -> 2.3.4
    applied eee8fdc3fe64... makedepend: upgrade 1.0.6 -> 1.0.7
    applied 383a0dccdccd... diffoscope: upgrade 221 -> 224
    applied 8b27e354bb83... mmc-utils: upgrade to latest revision
    applied b962d9cc23cc... libsoup-2.4: upgrade 2.74.2 -> 2.74.3
    applied caaa26ef5f8f... gdk-pixbuf: upgrade 2.42.9 -> 2.42.10
    applied 5f93750e9940... harfbuzz: upgrade 5.3.0 -> 5.3.1
    applied 4ec20a176929... netbase: upgrade 6.3 -> 6.4
    applied 73472f50b983... mpg123: upgrade 1.30.2 -> 1.31.1
    applied 8f04c0afe06e... sudo: upgrade 1.9.11p3 -> 1.9.12
    applied 11e54f1ff49f... alsa-lib: upgrade 1.2.7.2 -> 1.2.8
    applied f9e9707ed8c9... pango: upgrade 1.50.10 -> 1.50.11
    applied ae6305aa989a... pixman: upgrade 0.40.0 -> 0.42.2
    applied 445d2b967e62... vulkan: upgrade 1.3.224.1 -> 1.3.231.1
    applied 73a59c675656... gstreamer1.0: upgrade 1.20.3 -> 1.20.4
    applied c750c1f473d2... shaderc: upgrade 2022.2 -> 2022.3
    applied b3d0e068f72b... selftest: add a copy of previous mtd-utils version to meta-selftest
    applied 246051f11b2b... populate_sdk_ext: use ConfigParser instead of SafeConfigParser
    applied 36bff1aa4b0a... stress-ng: improve makefile use
    applied c2033689fa01... oeqa/selftest/lic_checksum: Cleanup changes to emptytest include
    applied 88385340d3ff... linux-firmware: don't put the firmware into the sysroot
    applied b29c66484a9e... python3: correctly adjust include paths in sysconfigdata
    applied 7763bd0d2f2c... pango: Make it build with ptest disabled
    applied ac9ea453b34f... bitbake: data: drop unused __expand_var_regexp__ and __expand_python_regexp__
    applied 361ae80a3164... bitbake: data_smart: allow python snippets to include a dictionary
    applied a31e8e22a338... migration guides: add release notes for 4.0.5
    applied ea0286609a86... docs: ref-manual: classes: fix section name for github-releases
    applied 85d6e1959103... docs: ref-manual: classes: add missing closing parenthesis
    applied f84f30253bcd... docs: poky.yaml.in: remove pylint3 from Ubuntu/Debian host dependencies
    applied e39e68053f4b... qemu.rst: audio: reference to Command-Line options
    applied 15a8edceadc3... ref-manual/variables.rst: expand BB_NUMBER_THREADS description
    applied 51b6a55a80fd... ref-manual/variables.rst: expand PARALLEL_MAKE description
    applied 40df2b19bd74... release-notes: use oe_git and yocto_git macros
    applied 25e2663a878c... libinput: upgrade 1.19.4 -> 1.21.0
    applied 02691744256d... classes: create-spdx: Move to version specific class
    applied f260b288020f... create-spdx: default share_src for shared sources
    applied 3a403ea562c7... libc-test: add libc testsuite for musl
    applied 44aeb523c85f... oeqa/selftest/minidebuginfo: Create selftest for minidebuginfo
    applied 60ab170228f0... glibc-locale: Do not INHIBIT_DEFAULT_DEPS
    applied 0f21df06a77c... package: Fix handling of minidebuginfo with newer binutils
    applied 5f0f366d1ab4... oeqa/qemurunner: update exception class for QMP API changes
    applied be8de607a991... oeqa/core/decorator: add decorators to skip based on HOST_ARCH
    applied 4c790357bf59... oeqa/selftest/buildoptions: skip test_read_only_image on qemuarm64
    applied ba9d3e732a14... oeqa/selftest/efibootpartition: improve test
    applied d72b13cef14f... oeqa/selftest/imagefeatures: remove hardcoded MACHINE in test_image_gen_debugfs
    applied 12b4cbbfee37... oeqa/selftest/imagefeatures: don't use wic images in test_hypervisor_fmts
    applied 3cb2640ad5e0... oeqa/selftest/imagefeatures: set a .wks in test_fs_types
    applied 92c1e7300f5a... oeqa/selftest/overlayfs: overlayfs: skip x86-specific tests
    applied 8e72283f546e... oeqa/selftest/package: generalise test_gdb_hardlink_debug()
    applied 31926bd1c10b... oeqa/selftest/package: improve test_preserve_ownership
    applied aa2016bcee3c... oeqa/selftest/runqemu: don't hardcode qemux86-64
    applied 45d9945c6aae... oeqa/selftest/runtime_test: only run the virgl tests on qemux86-64
    applied d3ec3aa81f50... oeqa/selftest/wic: skip more tests on aarch64
    applied 33b4cd0c0061... oeqa/selftest/wic: use skipIfNotArch instead of custom decorator
    applied c3ad78032870... classes/testexport: move to classes-recipe
    applied 6c7cf08dbf91... vala: install vapigen-wrapper into /usr/bin/crosscripts and stage only that
    applied 48abeedd63f0... sanity.bbclass: do not check for presence of distutils
    applied cf3fbfe04e83... pango: replace a recipe fix with an upstream submitted patch
    applied 05d6ea7ba922... libpciaccess: update 0.16 -> 0.17
    applied a3c26bcc6135... libxinerama: update 1.1.4 -> 1.1.5
    applied 221d645f8195... libxkbfile: update 1.1.0 -> 1.1.1
    applied 7dee87dc7472... libxmu: update 1.1.3 -> 1.1.4
    applied 4e34b94640f3... libxrender: update 0.9.10 -> 0.9.11
    applied 47e54e2dfd48... libxshmfence: update 1.3 -> 1.3.1
    applied fb5c3e65fc0d... libxtst: update 1.2.3 -> 1.2.4
    applied d53d0cf528c0... libxxf86vm: update 1.1.4 -> 1.1.5
    applied 231245127266... xcb-util: update to latest revisions
    applied 550d5fc0f36b... xf86-input-vmmouse: update 13.1.0 -> 13.2.0
    applied d97d3de1c446... gnomebase.bbclass: return the whole version for tarball directory if it is a number
    applied 1adc76edd25c... adwaita-icon-theme: update 42.0 -> 43
    applied e9bb0913e18e... libepoxy: convert to git
    applied 5ab5df637df8... libepoxy: update 1.5.9 -> 1.5.10
    applied 1bdf4c027339... rgb: update 1.0.6 -> 1.1.0
    applied 4e960cb2b524... meson: update 0.63.3 -> 0.64.0
    applied 45fd5150e320... systemd: update 251.4 -> 251.8
    applied 744cea3bfeeb... libxext: update 1.3.4 -> 1.3.5
    applied 3e5ce0275a43... scripts: convert-overrides: Allow command-line customizations
    applied cdd35d07a289... gpgme: Allow setuptools3-base to be excluded from the inherit list
    applied 6cd9a85d2b9f... sstatesig: skip the rm_work task signature
    applied 0f9773ee717d... rm_work: exclude the SSTATETASKS from the rm_work tasks sinature
    applied 7c1e70efccea... sstate: Allow optimisation of do_deploy_archives task dependencies
    applied b955eea19737... sanity: Drop data finalize call
    applied 20064a9e2a27... repo: upgrade 2.29.5 -> 2.29.9
    applied 130b55bdf381... spirv-tools: Correctly set the prefix in exported cmake packages
    applied 0d27fd75bda0... vulkan-loader: Allow headless targets to build the loader
    applied 889fc3a5cbad... gi-docgen: upgrade 2022.1 -> 2022.2
    applied 9244e8b004e2... libdrm: upgrade 2.4.113 -> 2.4.114
    applied 3e26f78d2227... mmc-utils: upgrade to latest revision
    applied 751f85a5d16a... mobile-broadband-provider-info: upgrade 20220725 -> 20221107
    applied ee43b20a6366... libsdl2: upgrade 2.24.1 -> 2.24.2
    applied 2140ca72b9dc... mesa: upgrade 22.2.2 -> 22.2.3
    applied 7764fb473895... python3-dtschema: upgrade 2022.9 -> 2022.11
    applied 868052c5f295... python3-flit-core: upgrade 3.7.1 -> 3.8.0
    applied a56d78fc2ab2... python3-pip: update 22.3 -> 22.3.1
    applied 459a12efc1be... python3-psutil: upgrade 5.9.3 -> 5.9.4
    applied 40e1f20df4e6... python3-setuptools: upgrade 65.5.0 -> 65.5.1
    applied 4e7a076d2cee... python3-sphinx-rtd-theme: upgrade 1.1.0 -> 1.1.1
    applied ca040077063a... python3-subunit: upgrade 1.4.0 -> 1.4.1
    applied 312975e571ee... python3-wheel: upgrade 0.38.0 -> 0.38.4
    applied 07eace6c0156... sed: update 4.8 -> 4.9
    applied 57d9840f1449... sudo: upgrade 1.9.12 -> 1.9.12p1
    applied de98b12ee177... sysstat: upgrade 12.6.0 -> 12.6.1
    applied d8e9ee8fd53b... bitbake: data/data_smart/build: Clean up datastore finalize/update_data references
    applied 1345caff4470... bitbake: gitsm: Fix regression in gitsm submodule path parsing
    applied 80e70e669fa6... bitbake: gitsm.py: process_submodules(): Set nobranch=1 for url
    applied 1c95f84c0c12... bitbake: toaster: fixtures/README: django 1.8 -> 3.2
    applied 574eccf19ad7... bitbake: toaster: fixtures/gen_fixtures.py: update branches
    applied 1a8272f40f07... bitbake: toaster: Add refreshed oe-core and poky fixtures
    applied 3b871a3793d8... systemd: add group render to udev package
    applied 992cbe818464... meta-selftest/staticids: add render group for systemd
    applied efc3f92a2903... babeltrace: upgrade 1.5.8 -> 1.5.11
    applied 8531a791933d... iso-codes: upgrade 4.11.0 -> 4.12.0
    applied 2845c06fff10... libsoup: upgrade 3.2.1 -> 3.2.2
    applied 75b77c72a3aa... wayland-protocols: upgrade 1.27 -> 1.28
    applied 93b26a86ef0b... xwayland: upgrade 22.1.4 -> 22.1.5
    applied f595da926eb6... gettext: update 0.21 -> 0.21.1
    applied 28ecbe0cc383... glib-2.0: update 2.72.3 -> 2.74.1
    applied 82e8c4105c8b... glib-networking: update 2.72.2 -> 2.74.0
    applied dececdc8e8bd... readline: update 8.1.2 -> 8.2
    applied 20d0bb142dd5... llvm: update 15.0.1 -> 15.0.4
    applied d2b7bf95fccb... make: update 4.3 -> 4.4
    applied e8a9e7490376... bash: update 5.1.16 -> 5.2.9
    applied 44bb88cc869f... mesa: do not rely on native llvm-config in target sysroot
meta-openembedded 6ebff843cc -> d04444509a:
    applied dd6ab68c21a5... python3-automat: Upgrade 20.2.0 -> 22.10.0
    applied 175af34c6654... python3-asttokens: Upgrade 2.0.8 -> 2.1.0
    applied 4f7f3c60c894... python3-lazy-object-proxy: upgrade 1.7.1 -> 1.8.0
    applied 89d59894c5b6... python3-luma-oled: upgrade 3.8.1 -> 3.9.0
    applied 750603583651... python3-nmap: upgrade 1.5.4 -> 1.6.0
    applied bc46bfe447ae... python3-pint: upgrade 0.20 -> 0.20.1
    applied dfeb555a6204... python3-protobuf: upgrade 4.21.8 -> 4.21.9
    applied 8621803f4941... python3-pytest-benchmark: upgrade 3.4.1 -> 4.0.0
    applied a72e91a08107... python3-pytest-html: upgrade 3.1.1 -> 3.2.0
    applied 30666bb8356b... python3-pytest-xdist: upgrade 2.5.0 -> 3.0.2
    applied b5cd6f6164eb... python3-requests-toolbelt: upgrade 0.10.0 -> 0.10.1
    applied 47f58bda43a5... python3-websockets: upgrade 10.3 -> 10.4
    applied be6245aefc74... samba: Fix install conflict with multilib enabled.
    applied 80549edfac17... python3-zeroconf: Upgrade 0.39.2 -> 0.39.4
    applied 9fbc1bdc4b11... libcompress-raw-bzip2-perl: upgrade 2.096 -> 2.201
    applied 926bcef2ed68... libcompress-raw-lzma-perl: upgrade 2.096 -> 2.201
    applied 085bfca80727... libcompress-raw-zlib-perl: upgrade 2.096 -> 2.202
    applied fb35ae0d4bca... libio-compress-lzma-perl: upgrade 2.096 -> 2.201
    applied ad10d0d3b5fe... libio-compress-perl: upgrade 2.096 -> 2.201
    applied 9497ca232586... fetchmail: Fix buildpaths warning.
    applied 38f5483127bf... libxpresent: upgrade 1.0.0 -> 1.0.1
    applied 721ed41c3380... xkbprint: upgrade 1.0.5 -> 1.0.6
    applied 43e39eb9c1c5... xmlsec1: upgrade 1.2.34 -> 1.2.36
    applied a703ff07a2ef... python3-imageio: Upgrade 2.22.2 -> 2.22.3
    applied 2518299aa5f1... python3-httplib: Upgrade 0.20.4 -> 0.21.0
    applied 8d45170e69c5... python3-twisted: Upgrade 22.8.0 -> 22.10.0
    applied 89653bab7189... minio: add recipe for minio client
    applied 66585ce7cab2... nftables: use automake ptest output format
    applied 62c29d9899c1... openwsman: Change download branch from master to main.
    applied c1b13a06827a... pugixml: upgrade 1.12 -> 1.13
    applied 983e9ad45a58... python3-brotli: Add new recipe for 1.0.9
    applied 254f37479ad2... hwdata: upgrade 0.363 -> 0.364
    applied 976578c9d1cb... lcms: upgrade 2.13.1 -> 2.14
    applied 2f113b14474f... libdbd-sqlite-perl: upgrade 1.70 -> 1.72
    applied 9aea1959de76... mosh: upgrade 1.3.2 -> 1.4.0
    applied 438a8b68b2b5... xfstests: upgrade 2022.10.09 -> 2022.10.30
    applied ca25528ad3d3... ulogd2: upgrade 2.0.7 -> 2.0.8
    applied df06118e8a7b... cli11: upgrade 2.3.0 -> 2.3.1
    applied 9152452b0155... ctags: upgrade 5.9.20221023.0 -> 5.9.20221106.0
    applied f177906504db... valijson: upgrade 0.7 -> 1.0
    applied cc976ef34403... openvpn: upgrade 2.5.7 -> 2.5.8
    applied 2167894b15f8... poco: upgrade 1.12.3 -> 1.12.4
    applied 2653feac2c6e... poppler: upgrade 22.10.0 -> 22.11.0
    applied 469a732d364b... satyr: upgrade 0.39 -> 0.40
    applied e3417247bcfe... ser1net: upgrade 4.3.8 -> 4.3.9
    applied 0c91d984c3c4... stunnel: upgrade 5.66 -> 5.67
    applied 58793ca934d3... wolfssl: upgrade 5.5.2 -> 5.5.3
    applied 5c5befa94d5b... tio: upgrade 2.2 -> 2.3
    applied 964ae9f79841... uhubctl: upgrade 2.4.0 -> 2.5.0
    applied 15029248d71d... zabbix: upgrade 6.2.3 -> 6.2.4
    applied c3de237ac70f... python3-spidev: upgrade 3.5 -> 3.6
    applied 80a64614ffa7... python3-gevent: upgrade 22.10.1 -> 22.10.2
    applied 346b36bdb7fc... python3-google-auth: upgrade 2.13.0 -> 2.14.0
    applied e6706635ced7... python3-greenlet: upgrade 1.1.3.post0 -> 2.0.0
    applied 30f5150d9345... python3-robotframework: upgrade 6.0 -> 6.0.1
    applied f7e7f5cc6199... python3-regex: upgrade 2022.9.13 -> 2022.10.31
    applied 4e075c7dc81c... python3-pillow: upgrade 9.2.0 -> 9.3.0
    applied ee2ff26643e8... python3-paramiko: upgrade 2.11.0 -> 2.12.0
    applied 29f49bb36ad1... meta-oe][PATCH] gst-editing-services: fix typo in LICENSE field.
    applied 0cbce7042b95... python3-jsonref: upgrade 0.3.0 -> 1.0.1
    applied 3bb4ee4ba116... geary: update 40.0 -> 43.0
    applied dd6072afc286... rest: upgrade 0.8.1 -> 0.9.0
    applied 58c538fda7d1... gnome-online-accounts: update 3.44.0 -> 3.46.0
    applied 0e600e3616d1... yelp: use libsoup-3.0 by default
    applied 476aab4fbcfa... surf: use libsoup-3.0 by default
    applied 5f1d47a81bca... python3-sqlalchemy: upgrade 1.4.42 -> 1.4.43
    applied f04689a7cd22... python3-websocket-client: upgrade 1.4.1 -> 1.4.2
    applied fac0727efdcb... python3-termcolor: upgrade 2.0.1 -> 2.1.0
    applied 8219c2eeccc7... python3-zopeinterface: upgrade 5.5.0 -> 5.5.1
    applied 7a52d62deb06... python3-tqdm: upgrade 4.64.0 -> 4.64.1
    applied b1381caa6136... openocd: fix build error
    applied d04444509a22... monkey: use git fetcher

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
