### PR TITLE
subtree update: 70d69cd844 -> b9af8750ac

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,13 +2,13 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 3d51e1117db9c89cf1c0f16e9436f45f6381ed0d
+last_revision = aecbb77f72c2eb087dd525e988f0f8a6ac55fb44
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 2ab113e8be42ae2dd61babb8e9a1742684df1f59
+last_revision = ea63f13846f47636b5caac7c5c38b6f7fcd66536
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
@@ -20,11 +20,11 @@ last_revision = 6c57b92708b3fd700ac24f8b754d980fc55bb074
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = 3d9dab6d1407f95a4bd059c8b16a5e2a66aaef06
+last_revision = 7eed4a60f594a1a90906acf3b3416d16c53bc72a
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 5e249ec855517765f4b99e8039cb888ffa09c211
+last_revision = 29afbb5e1449d03cce34192193dfd9b85d5fb081
 


### PR DESCRIPTION
meta-security 3d9dab6d14 -> 7eed4a60f5:
    applied 769ddade7391... linux-yocto.bbappend: bump to kernel version 6.x
    applied 92f04c78f0ed... meta-tpm: bump linux-yocto to 6.x kernel
    applied 7eed4a60f594... samhain: rework due to changed cache handling
meta-openembedded 2ab113e8be -> ea63f13846:
    applied 951f1edf19d3... poco: Do not use std::atomic<bool>
    applied cc396c8e9a50... libwebsockets: Fix build with gcc13
    applied 3210d3523fcd... v4l-utils: Fix build with gcc13
    applied 631ebd4a93a2... proj: Upgrade to 9.1.1 release
    applied ba5a86a51a45... mpd: Upgrade to 0.23.12 release
    applied 7eff93b1577b... geos: Upgrade to 3.9.4
    applied 0755cdd5152e... geos: Fix build with gcc13
    applied da03785ff19c... libinih: Upgrade to version 56
    applied 5c455804aede... python3-pybind11: Upgrade to 2.10.3
    applied 293f8baaddb9... waylandpp: Fix build with gcc-13
    applied f38c94f735d8... sedutil: Fix build with gcc13
    applied 87bf35072614... usbguard: Fix build with gcc13
    applied de569f111160... minifi-cpp: Fix build with gcc13
    applied 4f50432e2069... mbedtls: export source files/headers needed by ATF
    applied 674414be24b6... keyutils: fix Upstream-Status formatting
    applied bfb764ed8305... gphoto2: fix Upstream-Status formatting
    applied e99f1879662e... .patch: fix Upstream-Status formatting issues reported by patchreview tool from oe-core
    applied 304e75337da7... android-tools: fix Upstream-Status formatting
    applied cf6337634b41... mm-common: fix Upstream-Status formatting
    applied ea63f13846f4... .patch: fix Signed-off-by formatting issues reported by patchreview tool from oe-core
poky 5e249ec855 -> 29afbb5e14:
    applied 3e854407bb96... valgrind: Include missing <cstdint>
    applied d6f97cf27108... webkitgtk: Fix build with gcc 13
    applied d58a8a153cf2... gdk-pixbuf: do not use tools from gdk-pixbuf-native when building tests
    applied 6830aa2a3e5f... gdb: Define alignof using _Alignof when using C11 or newer
    applied 0c37cdbf5b59... lttng-modules: Fix for 5.10.163 kernel version
    applied 5bd43a58a75e... make-mod-scripts: Ensure kernel build output is deterministic
    applied 8c5faadf6cb9... bitbake.conf: Inject a dash into PN for BB_HASH_CODEPARSER_VALS
    applied fa4cd1a7a206... Revert "cve-update-db-native: show IP on failure"
    applied f3ad36d15ccb... newlib: Upgrade 4.2.0 -> 4.3.0
    applied 29afbb5e1449... scripts/bitbake-prserv-tool: Fix to work with memres bitbake
meta-arm 3d51e1117d -> aecbb77f72:
    applied 834f5aa9900b... arm/qemuarm-secureboot: Changes for v2023.01 u-boot
    applied e545d4ce5df4... arm-bsp/juno: update to use u-boot v2023.01
    applied b1a9035176b0... arm-bsp/juno: update kernel patches for 6.1
    applied aecbb77f72c2... arm-bsp/fvp-base: update kernel config to remove warning

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
