### PR TITLE
subtree update: cc4c72e390 -> 5f936deb19

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = aecbb77f72c2eb087dd525e988f0f8a6ac55fb44
+last_revision = dc10b73cc54fccbe781992b5b1eaf61cffbe07e6
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = ea63f13846f47636b5caac7c5c38b6f7fcd66536
+last_revision = cba6df61c7cbc4446aab09eb11673bcb6c581307
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 6c57b92708b3fd700ac24f8b754d980fc55bb074
+last_revision = e43af1e3a6d04231129bf543b3be9ff01fafd26d
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = 7eed4a60f594a1a90906acf3b3416d16c53bc72a
+last_revision = 3529cfb43e47015aa0621755e7b6536b7947d295
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 29afbb5e1449d03cce34192193dfd9b85d5fb081
+last_revision = aa6cd06a9fe7db56f13492ad13f034d6936268a3
 


### PR DESCRIPTION
poky 29afbb5e14 -> aa6cd06a9f:
    applied 86598c849cb5... busybox: 1.35.0 -> 1.36.0
    applied d119ac532f47... busybox: Make provisions to disable sha256/sha1 accelaration on x86
    applied 4360f7e2c16f... libtiff: add PACKAGECONFIG for libdeflate and zstd
    applied a10ec437b138... rust: Upgrade 1.66.1 -> 1.67.0
    applied e45fb1ff018b... nghttp2: Disable python bindings
    applied da95831d91b1... scons: Pass MAXLINELENGTH to scons invocation
    applied 7388cb224e3d... oeqa/qemurunner: do not use Popen.poll() when terminating runqemu with a signal
    applied 1a9437920a60... git: upgrade to 2.39.1
    applied 8b4d0c8cb85f... git: ignore CVE-2022-41953
    applied 61f27971a9aa... openssl: fix CVE-2022-3996 double locking leads to denial of service
    applied d8ec2bbc77b4... sdkext/cases/devtool: pass a logger to HTTPService
    applied f6a1c8c3098d... oeqa/utils/httpserver: connect up the request logging
    applied c24a83ed4a8d... httpserver: add error handler that write to the logger
    applied 7e36861eb3de... glslang: branch rename master -> main
    applied 72bcdc3755f4... poky.conf: Switch to post release name/version
    applied 1f6588bc00b0... linux-yocto/6.1: update to v6.1.7
    applied c112613967a5... linux-yocto/5.15: update to v5.15.89
    applied 885dd2abcc07... linux-yocto/6.1: cfg: remove depreciated configs
    applied 5a53270f3ec7... linux-yocto/6.1: update to v6.1.9
    applied 8c36e1557f51... linux-yocto/5.15: update to v5.15.91
    applied 94149c4f374f... meta: remove True option to getVar and getVarFlag calls (again)
    applied b2b53798f3bd... apt: fix do_package_qa failure
    applied 729c16b00e0e... python3-markupsafe: upgrade 2.1.1 -> 2.1.2
    applied a08c791bae13... gnutls: add ptest support
    applied 912977a3736a... oeqa/selftest/locales: Add selftest for locale generation/presence
    applied 96c105622915... xinetd: move xconv.pl script to separate package
    applied c79127dcb17d... rust: Add `update_snapshot` task to generate `rust-snapshot.inc`
    applied 4b85b092133d... sstate.bbclass: Fetch non-existing local .sig files if needed
    applied 61c35514cfd2... testimage: Fix error message to reflect new syntax
    applied 063bdffc0471... perf: Fix 6.1 kernel reproducibility issue
    applied d663b2b57b60... libtest-needs-perl: upgrade 0.002009 -> 0.002010
    applied 94ac339b9145... python3-pytest: upgrade 7.2.0 -> 7.2.1
    applied e95816334582... python3-hypothesis: upgrade 6.62.0 -> 6.66.0
    applied 7aeaa145586c... python3-poetry-core: upgrade 1.4.0 -> 1.5.0
    applied ca68fc154445... python3-iniconfig: upgrade 1.1.1 -> 2.0.0
    applied 11651cc4450f... python3-pytz: upgrade 2022.7 -> 2022.7.1
    applied 139a9b3a46a0... python3-zipp: upgrade 3.11.0 -> 3.12.0
    applied f82d12e5528a... python3-requests: upgrade 2.28.1 -> 2.28.2
    applied be78ee165cda... python3-sphinxcontrib-applehelp: 1.0.3 -> 1.0.4
    applied db641f8ef92a... python3-sphinxcontrib-htmlhelp: 2.0.0 -> 2.0.1
    applied 2df069c72526... python3-pyopenssl: upgrade 22.1.0 -> 23.0.0
    applied 5cba8c7e742a... python3-wcwidth: upgrade 0.2.5 -> 0.2.6
    applied 69b8b7ef1bd3... python3-urllib3: upgrade 1.26.13 -> 1.26.14
    applied 324b03e15fb8... base: add support for loongarch64
    applied f3889273f5d7... linux: add loongarch64 support
    applied 2f26104ebcae... binutils: disable gold on loongarch64
    applied a9eeffbf3603... loongarch: disable seccomp from default feature
    applied 0890c01d118d... uboot: add a loongarch64 entry
    applied fb0b2cf77279... scons.bbclass: Make MAXLINELENGTH overridable
    applied 7f670cf2d9c3... python3-pytest: Remove dependency on python3-toml
    applied 3ff392fb5854... perf: Enable debug/source packaging
    applied 1d8e6b0f9888... libc-locale: Fix on target locale generation
    applied 8e035db1e5f0... oeqa/selftest/locales: Add test for disabled binary locale generation
    applied 9724df2861d5... bitbake: bblayers/query: Replace layer directory name with layer name for show-layers
    applied 940cee8422eb... bitbake: bblayers/query: Adjust show-layers output layout
    applied de41e1737b60... bitbake: bitbake-user-manual: show how use BB_LOGCONFIG to log warnings
    applied edb60ef6fd49... bitbake: siggen: Fix inefficient string concatenation
    applied df58350c798b... glibc: Upgrade to 2.37 release
    applied c00e3de18fad... valgrind: Workaround glibc upgrade
    applied 2cc05cd5b35e... mesa: add PACKAGECONFIG for video-codecs
    applied 4577e76df822... python3-sphinx: upgrade 6.0.0 -> 6.1.3
    applied 30dccfb1b023... ell: update 0.55 -> 0.56
    applied 0800b8fff181... bootchart2: Fix usrmerge support
    applied daddc695fcb0... bitbake.conf: Add mercurial to HOSTTOOLS_NONFATAL
    applied b61e0002c1c1... uninative: Upgrade to 3.9 to include glibc 2.37
    applied 6aef6d8ccfd2... recipe_sanity: fix old override syntax
    applied 95e9a652bf78... lsof: fix old override syntax
    applied 75b70b625706... oeqa context.py: fix --target-ip comment to include ssh port number
    applied 9b5648ad17c4... btrfs-tools: upgrade 6.1.2 -> 6.1.3
    applied d49d6fe004c7... msmtp: upgrade 1.8.22 -> 1.8.23
    applied 50bfef53582e... image.bbclass: print all QA functions exceptions
    applied 184308335e46... update-alternatives: fix typos
    applied c09f2bf51b97... ifupdown: update 0.8.39 -> 0.8.41
    applied 1ab438d7d36f... python3-pip: update 22.3.1 -> 23.0
    applied e0ea87498dfb... diffutils: update 3.8 -> 3.9
    applied c4f80179ca50... mc: update 4.8.28 -> 4.8.29
    applied 372be4753e35... xf86-video-vmware: update 13.3.0 -> 13.4.0
    applied 6036baf811a3... lttng-tools: update 2.13.8 -> 2.13.9
    applied a6b1a24bc7bd... rt-tests: update 2.4 -> 2.5
    applied bc40185f163c... apr: update 1.7.0 -> 1.7.2
    applied 90c7540083fe... apr-util: update 1.6.1 -> 1.6.3
    applied a1b939703614... glib-2.0: upgrade 2.74.4 -> 2.74.5
    applied 2f97fb7ebcbb... systemd: update 252.4 -> 252.5
    applied 1663f59b57cb... cmake: upgrade 3.25.1 -> 3.25.2
    applied eef933b7de28... python3-setuptools: update 65.7.0 -> 67.2.0
    applied 7573d38c0109... lighttpd: upgrade 1.4.67 -> 1.4.68
    applied aef302222aa8... lsof: upgrade 4.96.5 -> 4.98.0
    applied 8d9f63edc1d8... igt-gpu-tools: upgrade 1.26 -> 1.27.1
    applied eb0839d986d7... vulkan-headers: upgrade 1.3.236.0 -> 1.3.239.0
    applied 4bb073f28964... vulkan-loader: upgrade 1.3.236.0 -> 1.3.239.0
    applied 8363e13b401b... vulkan-tools: upgrade 1.3.236.0 -> 1.3.239.0
    applied 387f83abe1cd... spirv-tools: upgrade 1.3.236.0 -> 1.3.239.0
    applied fe91d459fb9e... glslang: upgrade 1.3.236.0 -> 1.3.239.0
    applied 768fced491f9... spirv-headers: upgrade 1.3.236.0 -> 1.3.239.0
    applied 6e4407b6f34d... libxpm: upgrade 3.5.14 -> 3.5.15
    applied 665b76e383c9... rng-tools: upgrade 6.15 -> 6.16
    applied afd2d02bfc8d... fontconfig: upgrade 2.14.1 -> 2.14.2
    applied 3c1501a53985... ncurses: upgrade 6.3+20220423 -> 6.4
    applied d81967c62347... mpg123: upgrade 1.31.1 -> 1.31.2
    applied 33ad19834690... python3-pycryptodomex: upgrade 3.16.0 -> 3.17
    applied 819c5611edfc... bind: upgrade 9.18.10 -> 9.18.11
    applied 80e1f5a8a411... libjpeg-turbo: upgrade 2.1.4 -> 2.1.5
    applied b95d1edb79d7... pkgconf: upgrade 1.9.3 -> 1.9.4
    applied 4f9417f59231... python3-pycryptodome: upgrade 3.16.0 -> 3.17
    applied 090ae55e59aa... python3-dtschema: upgrade 2022.12 -> 2023.1
    applied d70605836b29... llvm: upgrade 15.0.6 -> 15.0.7
    applied 3f836755ce77... puzzles: upgrade to latest revision
    applied 73419d5a92bf... dpkg: upgrade 1.21.18 -> 1.21.19
    applied d1625bcdffbd... shaderc: upgrade 2022.4 -> 2023.2
    applied 44d6a427c417... sysstat: upgrade 12.6.1 -> 12.6.2
    applied 0f27bd7615ed... piglit: upgrade to latest revision
    applied abc6c7fc1af8... ltp: upgrade 20220930 -> 20230127
    applied fe7fcc983a33... linux-firmware: upgrade 20221214 -> 20230117
    applied 47a81926178a... libinput: upgrade 1.22.0 -> 1.22.1
    applied 5e509494dfa4... sudo: upgrade 1.9.12p1 -> 1.9.12p2
    applied 7770bfcc8011... diffoscope: upgrade 230 -> 234
    applied 050f57103564... texinfo: upgrade 7.0.1 -> 7.0.2
    applied eefbbe5d93a7... stress-ng: upgrade 0.15.02 -> 0.15.03
    applied 5ecb64f893e8... libgit2: upgrade 1.5.0 -> 1.5.1
    applied 3e2ef40f4076... python3-pathspec: upgrade 0.10.3 -> 0.11.0
    applied 4e7394ffefb5... ffmpeg: fix configure failure on noexec /tmp host
    applied 0f1af550ef17... systemd: add PACKAGECONFIG for pstore
    applied e911d154cedb... lttng-tools: Update LFS64 patch with upstream feedback
    applied aa6cd06a9fe7... bitbake: fetch2: Add NODE_EXTRA_CA_CERTS to export list
meta-security 7eed4a60f5 -> 3529cfb43e:
    applied 3529cfb43e47... linux-yocto: drop version from bbappends
meta-raspberrypi 6c57b92708 -> e43af1e3a6:
    applied 1d8a12ffa7fb... linux-raspberrypi: Update to 5.15.90
    applied 3c5959ba8512... linux-raspberrypi: Fix build with gcc13
    applied a02173f59772... linux-raspberrypi: Remove unused patches
    applied c759b5edf38c... raspidmx, userland, omxplayer: Fix Upstream-Status formatting
    applied c9d9582a2385... linux-raspberrypi: Build eeprom access into kernel
    applied e43af1e3a6d0... rpi-eeprom: Add recipe for eeprom update/configuration
meta-arm aecbb77f72 -> dc10b73cc5:
    applied 7ac8d1e2a5f2... arm-bsp/corstone*00: disable openssl in kmod
    applied 8891820e97b2... CI: pin to kas 3.2 as 3.2.1 fails
    applied 4704bf12921d... meta-arm: add build to gitignore
    applied 47872289aecc... kas/corstone1000: move from langdale to master
    applied 5577b381645c... arm-bsp/corstone500: bump u-boot version to 2023.01
    applied 30796fb798d4... arm-bsp/corstone1000: bump u-boot version to 2023.01
    applied 03574e91737c... arm-bsp: corstone500: bump kernel version to 6.1
    applied 894e309eaf6b... arm-bsp/corstone1000: bump kernel version to v6.1
    applied 37fd476ae1f2... gator-daemon: Fix build with gcc13
    applied 70fbe7fe1286... sbsa: Fix build with gcc13
    applied dc10b73cc54f... arm/linux-yocto: avoid kernel defconfig warning
meta-openembedded ea63f13846 -> cba6df61c7:
    applied a0261da7b9f3... rwmem: Update to latest
    applied e6119b2f3425... pipewire: Split dymanic modules to target recipe alone
    applied c289caf77669... samba: upgrade 4.17.4 -> 4.17.5
    applied 0416a4e53872... libb64: reactivate BUFFERSIZE patch
    applied 6ec4f0a30fc3... upm: Fix build with gcc13
    applied 6f731d43f5d2... openthread: Use __attribute__ ((unused)) instead of removing 't'
    applied 24724ee764cc... wireshark: Add nghttp2 packageconfig
    applied b055d708ae2a... rdma-core: Inherit python3targetconfig
    applied 469b1a52f414... wireshark: Inherit python3targetconfig
    applied 905860728375... hplip: Inherit python3targetconfig
    applied 0d973d9470f0... hplip: Inherit python3targetconfig
    applied 426a1e4f8f2e... dante: Add -P to preprocessor flags
    applied 817ef78198cd... breakpad: Fix build with gcc13
    applied effbeeff2ee8... mongodb: Fix build with gcc13
    applied 7c82652b2a0f... mongodb: Upgrade to 4.4.18
    applied 94e34a6d910a... mongodb: Pass MAXLINELENGTH to scons invocation
    applied 7f456b1f0026... perfetto: Disable ccache
    applied df4f8a675f75... nodejs: Fix build with gcc13
    applied d3a5cfe7488a... softhsm: avoid unnecessary check for native sqlite binary
    applied 630e29d3166c... softhsm: enable objectstore backend
    applied 81d607b2676c... hunspell: move ispellaff2myspell script to separate package
    applied 20bc73a86ef4... zeromq: Fix build with gcc13
    applied e16db79ffc95... python3-greenlet: Fix build with gcc13
    applied 71d2adfc5f3e... perfetto: Upgrade to 31.0 release
    applied 1b7fd40fb3b7... perfetto: Fix build with gcc13
    applied 1ead4748deb8... ntopng: Add hiredis to depends
    applied 81b769d0981b... python3-grpcio: Fix build with gcc13
    applied 6cdb98eed2d6... tesseract: Fix build with gcc13
    applied 6e3b7aa52718... lcdproc: Update to latest tip of trunk
    applied 60084508a4f1... mongodb: Use bfd linker for x86/musl with gcc
    applied f05ea5c2e81b... syslog-ng: workaround segfault for ppc64le
    applied 3a6dd415f124... initramfs-{debug,kexecboot}-image: fix override syntax in comment
    applied 81ec075c48a5... kexecboot: update homepage
    applied 670bd4e3aeb1... python3-pycups: add recipe
    applied 65ac92781f0f... blueman: add missing runtime dependency, add polkit rule
    applied 7b0e71e00ce1... python3-pillow: add ptest support
    applied 01cc91abb68f... extract-cert: add recipe
    applied 195caefc6577... gegl: Depend on openmp when using clang
    applied 49c1e98885eb... meta: remove True option to getVar calls (again)
    applied 2325739f662c... concurrencykit: Make patch compatible with Bourne shell
    applied 8d298ef6d8b7... system-config-printer: add recipe
    applied 4ff9097409a4... rtkit: add recipe
    applied f8a25ccf549a... pipewire: Do not split modules using PACKAGES_DYNAMIC for native case
    applied cc5082d5d156... opensc: fix private key import
    applied 3436f1507052... xdg-desktop-portal: add runtime dependency on rtkit
    applied 1534ca7afe81... sysdig: Fix build with gcc13
    applied 7ecfc7957369... zfs: Update to 2.1.9
    applied a83305a15dfe... pipewire: update 0.3.64 -> 0.3.65
    applied 963f55df9efc... minicoredumper: Add ptest
    applied dec789229aa6... mdns: Upgrade 1790.60.25 -> 1790.80.10
    applied 4dead11edb63... mctp: fix overrides syntax in SYSTEMD_AUTO_ENABLE:${PN}
    applied 6ddc13587365... xfdesktop: update 4.18.0 -> 4.18.1
    applied 5da852a61620... python3-isort: Upgrade to isort 5.12.0
    applied 5c43f2b9a15b... minicoredumper: Upgrade to 2.0.2 release
    applied 71d152d23c1f... perfetto: Add missing dependencies.
    applied 6e3804a155da... vulkan-cts: Rename patch to avoid problems on case insensitive filesytems
    applied 4b3e6289cd4c... python3-greenlet: Upgrade to 2.0.2
    applied 927b9b848766... crda: remove recipe
    applied 6e8c90560e0a... python3-pillow: add tk to RDEPENDS ptest pkg only if x11 in DISTRO_FEATURES
    applied 4f43546c0244... dnsmasq: Upgrade 2.88 -> 2.89
    applied 481467514e68... cups-filters: Fix build with clang16/c++17
    applied 3d74a8d07d36... cups-filters: Upgrade to 1.28.17 release
    applied ac69a017011b... ltrace: Fix build with clang16
    applied 26fb498ed3c9... oprofile: Do not use std::bind2nd
    applied b67a20e35a4d... perfetto: Fix build on musl again
    applied 85aa214ce00a... frr: upgrade 8.4.1 -> 8.4.2
    applied 84331a6ddc0d... byacc: upgrade 20221229 -> 20230201
    applied 8c5927b7618f... ccid: upgrade 1.5.1 -> 1.5.2
    applied 62ad5756d683... cglm: upgrade 0.8.7 -> 0.8.9
    applied 69aea3d8f7d8... cmark: upgrade 0.30.2 -> 0.30.3
    applied cba6df61c7cb... apache2: upgrade 2.4.54 -> 2.4.55

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
