### PR TITLE
subtree update: fdfc54a7fc -> 349c84011b

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 9b6c8c95e47f4ddfcd462025733071edc1c56369
+last_revision = c60d7865ddeb49578e949462ab184940be3b6913
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 17243e70c8309751a1129a9214899ec476ab121a
+last_revision = c5f330bc9ae72989b8f880aa15e738a3c8fce4e7
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 3afdbbf782120edd08b15f947429cce075543513
+last_revision = bf948e0aa87ee0c10bdf85f99b2632915e6d2039
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = a397a38ed9e54378e66ce750a005bda14991b719
+last_revision = 53c5cc794f44df96c47c614d736c8ccd4f25139f
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 0907793d5e35b418e298e3cb739de85b0db1d24e
+last_revision = cce6db2a59d309f77c1f9ca173fc674c506062d0
 


### PR DESCRIPTION
meta-security a397a38ed9 -> 53c5cc794f:
    applied ab80ee71de... checksecurity: update to 2.0.16
    applied 415424a706... krill: forced to inclued fetch hashes.
    applied ffe3d73fad... suricata: Fixup to work within the recent crate changes.
    applied a149c85ce9... suricata: Missed on crate depends
    applied 9d819c1242... libwhisker2-perl: adjust perl-version variable
    applied cdd4295689... meta-parsec: Disable RSA-OAEP OEQA tests for Parsec PKCS11 backend
    applied f0d1f808b7... parsec-service: Update parsec recipes to 1.2.0 and parsec-tool to 0.6.0
    applied 3d6ff465ce... parsec-tool: update SRC_URI hash
    applied 9d21e48053... parsec-service: fix SRC_URI hash
    applied 3b0659d50f... Fix PACKAGECONFIG check in Parsec OEQA tests
    applied 53c5cc794f... Flush caches after OEQA tests
meta-openembedded 17243e70c8 -> c5f330bc9a:
    applied f290449c6c... libpcsc-perl: Add recipe
    applied 06cd3f757d... pcsc-tools: Add runtime dependencies
    applied c2ddfe8b3a... mcelog: improve the ptest output
    applied 53b7f23590... hplip: Fix installation and QA
    applied 2f06781b87... libgusb: Allow building in native mode
    applied 1807ecfe4b... krb5: Fix build with autoconf 2.72
    applied babd1cbf85... cyrus-sasl: Fix autoconf patch to work with new autoconf 2.72
    applied 2b4e21be8e... gmime: Update to 3.2.13
    applied db87078a40... imagemagick: Update to 7.1.1
    applied 9937ffa5d2... nginx: added packagegroup for webdav module
    applied 55489e5d10... nv-codec-headers: add clean target to Makefile
    applied f6b3a82e1e... reboot-mode: put the build artifacts in ${B}
    applied fb3430b8f3... flatpak: update 1.15.3 -> 1.15.4
    applied 17180ae0d2... libcamera: re-introduce fix for gcc-13
    applied 7733744d98... mpv: Upgrade to 0.35.1
    applied 0dbd8cf7d0... fwknop: Use pkg-config instead of gpgme-config
    applied 77c6192de7... fwknop: Fix AS_IF configure syntax
    applied 60afa577e5... libstemmer: Update to 2.2.0
    applied f7fc137e13... libidn: Update largefile m4 macros
    applied 77f4b570bf... emacs: Fix build with autconf 2.72+
    applied 306a92cdba... cli11: do not inherit ptest
    applied 0fc5f550d3... span-lite: do not inherit ptest
    applied d094f80089... ptest-packagelists-meta-oe.inc: add ptest recipes
    applied ec3760af48... meta-oe-ptest*-image: enable BBCLASSEXTEND parallel execution
    applied 580c36fa72... ptest-packagelists-meta-oe: Remove minicoredumper from PTESTS_FAST_META_OE on musl
    applied 69d921a342... ptest-packagelists-meta-python.inc: add ptest recipes
    applied 80e9601cc8... meta-python-ptest*-image: enable BBCLASSEXTEND parallel execution
    applied c09cc8ddde... python3-aspectlib: fix ptest
    applied 99972beb1d... ptest-packagelists-meta-perl.inc: add ptest recipes
    applied 480985d35e... recipes-perl/packagegroups: move to recipes-core/
    applied fdc87348a0... recipes-perl/images: move to recipes-core
    applied 90589558e9... meta-perl-ptest*-image: enable BBCLASSEXTEND parallel execution
    applied 9357ea2698... poco: Remove pushd/popd from run-ptest
    applied 356b224344... redirect unwanted error message in nginx install
    applied b3274b4e90... jemalloc: include the missing shell scripts and source the corresponds shell scripts for some test cases.
    applied 63bb96035b... abseil-cpp: upgrade 20230125.1 -> 20230125.2
    applied 3f5f2f067b... libbytesize: upgrade 2.7 -> 2.8
    applied 6dd05f5463... gegl: upgrade 0.4.42 -> 0.4.44
    applied e992fa00fc... ctags: upgrade 6.0.20230319.0 -> 6.0.20230402.0
    applied 9fe311dfb2... libdeflate: upgrade 1.17 -> 1.18
    applied d414cd15b3... libldb: upgrade 2.7.1 -> 2.7.2
    applied a014528ede... ndisc6: upgrade 1.0.6 -> 1.0.7
    applied 15b2d49d34... libpfm4: upgrade 4.12.0 -> 4.13.0
    applied d250a0dc02... libtraceevent: upgrade 1.7.1 -> 1.7.2
    applied 184fd210ea... nginx: upgrade 1.23.3 -> 1.23.4
    applied fadf73e5f6... links: upgrade 2.28 -> 2.29
    applied 2a8a340385... python3-pyproj: upgrade 3.4.1 -> 3.5.0
    applied e2ac0e39f9... ostree: upgrade 2023.1 -> 2023.2
    applied fc221b3211... openvpn: upgrade 2.6.1 -> 2.6.2
    applied 33d583fc3f... python3-aenum: upgrade 3.1.11 -> 3.1.12
    applied 46ab1a3f4f... samba: upgrade 4.18.0 -> 4.18.1
    applied 8c71f78cda... polkit-gnome: add recipe
    applied 9d57484309... eog: update 43.2 -> 44.0
    applied 0aa35468e1... evince: update 43.1 -> 44.0
    applied 994b931880... gdm: update 43.0 -> 44.0
    applied 4ae910baf4... gnome-calculator: update 43.0.1 -> 44.0
    applied b6b9b9a9a6... gnome-calendar: update 43.1 -> 44.0
    applied 5c61681895... gnome-desktop: update 43 -> 44.0
    applied 9bb1448081... gnome-disk-utility: update 43.0 -> 44.0
    applied 11b63d454b... gnome-font-viewer: update 43.0 -> 44.0
    applied bba29b70e9... gnome-online-accounts: update 3.46.0 -> 3.48.0
    applied 83cfafbdfd... gnome-photos: update 43.0 -> 44.0
    applied 9a3c4fafd3... gnome-session: update 43.0 -> 44.0
    applied 0cf97066d3... gnome-settings-daemon: update 43.0 -> 44.0
    applied b7f19d65c2... gnome-shell-extensions: update 43.1 -> 44.0
    applied 4927a29399... gnome-software: update 43.4 -> 44.0
    applied 77acbaa680... gnome-terminal: update 3.46.7 -> 3.48.0
    applied 724b0528da... gnome-text-editor: update 43.1 -> 44.0
    applied 05dfe25feb... tracker-miners: update 3.4.2 -> 3.5.0
    applied 7fb1009e2d... zenity: update 3.43.0 -> 3.44.0
    applied f4ebefcb16... xdg-desktop-portal-gnome: update 43.1 -> 44.0
    applied 2ce3c15e1f... gedit: update 43.2 -> 44.2
    applied 3ccb099e21... surf: Fix build with gtkwebkit 2.40
    applied 3b8aeef1c3... evolution-data-server: build oauth with gtk+3
    applied a34c6b77a3... python3-argcomplete: upgrade 3.0.0 -> 3.0.5
    applied e2056558b3... python3-cassandra-driver: upgrade 3.25.0 -> 3.26.0
    applied 2f3578b4ce... python3-astroid: upgrade 2.15.0 -> 2.15.1
    applied f0e8b2d003... python3-cmake: upgrade 3.26.0 -> 3.26.1
    applied 3bed7e365b... python3-dateparser: upgrade 1.1.7 -> 1.1.8
    applied da5190344b... python3-google-api-python-client: upgrade 2.81.0 -> 2.83.0
    applied 06ed48730d... python3-elementpath: upgrade 4.0.1 -> 4.1.0
    applied 0f36acd433... python3-googleapis-common-protos: upgrade 1.58.0 -> 1.59.0
    applied 4665ccd8d9... python3-httplib2: upgrade 0.21.0 -> 0.22.0
    applied d2a13a69ab... python3-google-auth: upgrade 2.16.2 -> 2.17.1
    applied d7ea5a9942... python3-ipython: upgrade 8.11.0 -> 8.12.0
    applied ac3d796281... python3-imageio: upgrade 2.26.0 -> 2.27.0
    applied a34202abe7... python3-pychromecast: upgrade 13.0.4 -> 13.0.6
    applied bb8819a9b5... python3-jdatetime: upgrade 4.1.0 -> 4.1.1
    applied 35e7f76326... python3-luma-oled: upgrade 3.11.0 -> 3.12.0
    applied ea63c2de22... python3-pydantic: upgrade 1.10.6 -> 1.10.7
    applied 5447a49ce2... python3-pymodbus: upgrade 3.2.1 -> 3.2.2
    applied 1911fd29e0... python3-pymisp: upgrade 2.4.169.2 -> 2.4.169.3
    applied 76396d6bf1... python3-pywbemtools: upgrade 1.1.1 -> 1.2.0
    applied 5f3ca17c07... python3-redis: upgrade 4.5.1 -> 4.5.4
    applied 9917d11343... python3-regex: upgrade 2022.10.31 -> 2023.3.23
    applied d871faa66b... python3-typeguard: upgrade 3.0.1 -> 3.0.2
    applied 3ba7498ed9... python3-sentry-sdk: upgrade 1.17.0 -> 1.18.0
    applied d83bc4853f... python3-rich: upgrade 13.3.2 -> 13.3.3
    applied 0d028d944e... python3-watchdog: upgrade 2.3.1 -> 3.0.0
    applied c6893fda3e... jwt-cpp: enable usage in an SDK
    applied 20d2eeb62a... sox: remove ffmpeg dependency
    applied 6e4063c1d8... libio-pty-perl: Fix build with musl/clang
    applied 9f6268e283... zsh: fix installed-vs-shipped with multilib
    applied b1d0b6f06c... python3-crc32c: Correct the license information
    applied 71e75357af... paho-mqtt-cpp: Improve the license information
    applied 506b6c9411... autossh: Correct the license information
    applied 4decf7d0a7... paho-mqtt-c: Improve the license information
    applied 2e0a581bee... recipes: Remove double protocol= from SRC_URIs
    applied 7e4947d0b0... meta-python: python3-path: Add ptest
    applied 74dcb3aa17... meta-python: python3-lorem: Add ptest
    applied 1dc0260309... meta-oe: recipes-support: dc: Add ptest
    applied 8247b9efce... meta-gnome: Update patch status for several recipes
    applied c5f6d0b19b... libnet-ssleay-perl: Fix patch upstream status
    applied 77a32ac2b7... meta-xfce: Fix missing upstream status in patches
    applied 9e42462d5a... meta-multimedia: Fix missing upstream status in several patches
    applied cb125e2bef... meta-webserver: Fix missing upstream status on patches
    applied a80e993aec... babl: Drop clang10 workaround for mips/rv64
    applied 3e4121b6e7... babl: Package /usr/lib/babl-0.1/ directory
    applied 8b0fe7a1d1... libtinyxml2: Add ptest support
    applied dd5e852516... ptest-packagelists-meta-oe: Add libtinyxml2
    applied f1ab25b104... minifi-cpp: Always use stat on 64bit linux
    applied c126f16db2... android-tools: fix systemd service setting
    applied 8986c108f4... file-roller: set cpio path manually
    applied f19dac11ff... meta-oe: recipes-extended: bitwise: Add ptest
    applied 6d22cd4c12... libdnet: Upgrade to 1.16.3
    applied 55074903fe... uutils-coreutils: Add crates checksum
    applied 1854b495bb... uutils-coreutils: remove obsolete comment
    applied 4ee5e2badb... uutils-coreutils: upgrade 0.0.17 -> 0.0.18
    applied 6b197f009d... uutils-coreutils: disable musl support
    applied 08a95252e8... python3-pyruvate: regenerate with updated bbclass
    applied 4b78dc1c44... libdecor: update 1.1.0 -> 1.1.99
    applied 3d355d3d9c... xfce4-taskmanager: 1.5.2 -> 1.5.5
    applied ae1580992c... xfce4-terminal: 1.0.0 -> 1.0.4
    applied 9becb31475... syslog-ng: not deliver syslog-ng-update-virtualenv
    applied 89ca8235d4... restinio: fix S variable in multilib builds
    applied 8522bccead... mongodb: fix chown user for multilib builds
    applied 3a8e18f038... monkey,webmin: Fix upstream patch status
    applied 44147c5bb7... pahole: respect libdir
    applied faa9d6a7b1... lvgl,lv-lib-png,lv-drivers: fix installed-vs-shipped QA issue with multilib
    applied ae8ea03c44... xfce4-notifyd: 0.6.3 -> 0.8.2
    applied 621a2a3779... xfce4-screenshooter: 1.9.10 -> 1.10.3
    applied 95a76614a6... python3-pyruvate: Upgrade to 1.2.1
    applied 38dda849d5... freerdp: set PROXY_PLUGINDIR
    applied 8486680d5b... libnfs: add recipe
    applied 07ca097d36... pipewire: update 0.3.67 -> 0.3.68
    applied 39c55bc614... iwd: update 2.3 -> 2.4
    applied 4f61fe65af... feh: upgrade 3.9.1 -> 3.10
    applied 6edb29898e... c-periphery: upgrade 2.3.1 -> 2.4.0
    applied fd7821f412... grilo-plugins: upgrade 0.3.15 -> 0.3.16
    applied 895286ce04... hwdata: upgrade 0.368 -> 0.369
    applied e634d3def8... hwloc: upgrade 2.9.0 -> 2.9.1
    applied a0ce9aa790... libconfig-tiny-perl: upgrade 2.28 -> 2.29
    applied 6364b4bf7f... mg: upgrade 20221112 -> 20230406
    applied ebe266a0b4... python3-pillow: upgrade 9.4.0 -> 9.5.0
    applied 05dda95465... python3-websockets: upgrade 10.4 -> 11.0.1
    applied 02331987d0... poppler: upgrade 23.03.0 -> 23.04.0
    applied 68ee3ed5fb... python3-alembic: upgrade 1.10.2 -> 1.10.3
    applied 1d58644dcd... python3-astroid: upgrade 2.15.1 -> 2.15.2
    applied 4ea55900fd... python3-coverage: upgrade 7.2.2 -> 7.2.3
    applied 398bdf2e38... python3-google-api-python-client: upgrade 2.83.0 -> 2.84.0
    applied c77c509218... python3-google-auth: upgrade 2.17.1 -> 2.17.2
    applied 1290752044... python3-imgtool: upgrade 1.9.0 -> 1.10.0
    applied 82ce84ecc6... python3-pychromecast: upgrade 13.0.6 -> 13.0.7
    applied 3c49711ad7... python3-simplejson: upgrade 3.18.4 -> 3.19.1
    applied ae43241fa2... python3-networkx: upgrade 3.0 -> 3.1
    applied ff8375af85... tesseract: upgrade 5.3.0 -> 5.3.1
    applied 8f2476d29b... python3-zeroconf: upgrade 0.47.4 -> 0.55.0
    applied c402247a9b... python3-web3: upgrade 6.0.0 -> 6.1.0
    applied bbf30898f3... python3-sqlalchemy: upgrade 2.0.7 -> 2.0.9
    applied 942740b286... python3-sentry-sdk: upgrade 1.18.0 -> 1.19.1
    applied 8e6474a1f1... thunar: 4.18.0 -> 4.18.4
    applied d23c91f722... thunar-media-tags-plugin: 0.3.0 -> 0.4.0
    applied 3d09ca7404... mozjs: update 102.5.0 -> 102.9.0
    applied 3d0279c187... glibmm: fix reproducibility issues
    applied c466df4d50... adw-gtk3: add recipe
    applied 9317d99070... dleyna-{server,renderer}: fix dev-so QA issue with multilib
    applied 385ca58f98... lirc: fix do_install with multilib
    applied 366af48fa5... nss: fix failed test of nss.
    applied 2e70cf3552... qrencode: add PACKAGECONFIG for command line tools
    applied 5a50070964... qrencode: enable native build
    applied 66ed68b607... libgpiod: enable all features for ptest
    applied 0db97d732b... libgpiod: drop unneeded S assignment
    applied cf6291bf64... libgpiod: generalize the local files directories
    applied bb9d3afe9d... libgpiod: update to v2.0.1
    applied 61e84230ae... python3-gpiod: don't hardcode the project version in recipe
    applied 70a8e303d3... php: Fix GCC 12 -Og
    applied 0e272e17be... xdg-desktop-portal-wlr: update
    applied fa02a3f087... libxfce4util: 4.18.0 -> 4.18.1
    applied 94fade6442... libxfce4ui: 4.18.0 -> 4.18.3
    applied f9ef3f5f5c... xfce4-settings: 4.18.0 -> 4.18.2
    applied 73ef8e4ec0... xfce4-session: 4.18.0 -> 4.18.2
    applied f7a6c2ebdc... xfce4-panel: 4.18.0 -> 4.18.3
    applied 9d0f892a26... hdf5: Fix install conflict when enable multilib.
    applied 18ef546186... onig: Ignore .debug directories while finding ptests
    applied e64fda2f96... cockpit: upgrade 276 -> 289
    applied ad73ee286f... dlt-daemon: fix CVE-2023-26257
    applied 1a6b24b78c... khronos-cts: Replace wayland feature dependancy with vulkan
    applied ce5cf625cd... python3-gpiod: add missing run-time dependencies
    applied 62cd19e3f4... libgpiod: install the libgpiosim header
    applied 930436d900... python3-gpiod: fetch sources from pypi
    applied c6243e1b6a... libgpiod: fold libgpiod-src.inc into libgpiod.inc
    applied d7001f534e... nftables: upgrade 1.0.6 -> 1.0.7
    applied 5564dbb8ff... python3-gcovr: Add missing runtime dependency
    applied 56ac2a69a8... python3-h5py: Fix TMPDIR references in dbg files
    applied 1b7380bc0f... python3-pandas: Fix TMPDIR references in dbg files
    applied 24d8984345... capnproto: upgrade 0.10.3 -> 0.10.4
    applied 2825d8f63f... ctags: upgrade 6.0.20230402.0 -> 6.0.20230416.0
    applied 4b28dff276... mctp: upgrade 1.0 -> 1.1
    applied 486153255d... php: upgrade 8.2.4 -> 8.2.5
    applied f613df1f33... openvpn: upgrade 2.6.2 -> 2.6.3
    applied 63d1875430... python3-croniter: upgrade 1.3.8 -> 1.3.14
    applied c0ab58aa04... python3-diskcache: upgrade 5.4.0 -> 5.5.1
    applied cbe106d4a1... python3-cmake: upgrade 3.26.1 -> 3.26.3
    applied 6d86ed5ab5... python3-elementpath: upgrade 4.1.0 -> 4.1.1
    applied 407ef093bb... python3-google-api-python-client: upgrade 2.84.0 -> 2.85.0
    applied 336d9a4eee... python3-google-auth: upgrade 2.17.2 -> 2.17.3
    applied 604efddff8... python3-protobuf: upgrade 4.22.1 -> 4.22.3
    applied 6ea2e3ec8e... python3-web3: upgrade 6.1.0 -> 6.2.0
    applied 561990f983... python3-rich: upgrade 13.3.3 -> 13.3.4
    applied c21ffb1403... python3-pymisp: upgrade 2.4.169.3 -> 2.4.170
    applied 3e3799c49c... python3-xlsxwriter: upgrade 3.0.9 -> 3.1.0
    applied 18b3626576... python3-zeroconf: upgrade 0.55.0 -> 0.56.0
    applied 76822f04fa... remmina: upgrade 1.4.29 -> 1.4.30
    applied 2e53376646... tbb: upgrade 2021.8.0 -> 2021.9.0
    applied 016f6ae65c... sip: upgrade 6.7.7 -> 6.7.8
    applied bac63db5dc... thunar-archive-plugin: 0.5.0 -> 0.5.1
    applied b94459b74a... xfce4-power-manager: 4.18.0 -> 4.18.1
    applied b85b46da3e... garcon: 4.18.0 -> 4.18.1
    applied 3368f763b5... xfce4-screensaver: 4.16.0 -> 4.18.1
    applied 2e782260d0... tcpdump: upgrade 4.99.3 -> 4.99.4
    applied 49e92e4135... tcsh: upgrade 6.24.07 -> 6.24.10
    applied 62a3fa25e4... fwupd: Do not emit build time paths into generated headers
    applied 8eb74815c2... libcereal: Fix TMPDIR leaking into debug_str section
    applied 54f5199706... python3-appdirs: add native and nativesdk to BBCLASSEXTEND
    applied 9d66f76045... xmlrpc-c: Upgrade to 1.59.01
    applied cd8c45f492... grilo: Fix buildpaths in generated header file
    applied db57123c49... p7zip: fix for CVE-2018-5996
    applied 102abb1c33... p7zip: Fix for CVE-2016-9296
    applied daa0c135a8... pipewire: remove 'inherit gsettings'
    applied 648912f72d... ntp: whitelist CVE-2019-11331
    applied 2e0615b1d3... vbxguestdrivers: upgrade 7.0.4 -> 7.0.8
    applied afbc223489... libgpiod: remove test executables from ${bindir}
    applied 864f99b885... etcd-cpp-apiv3: add recipe
    applied 9199351a8a... evolution-data-server: upgrade 3.48.0 -> 3.48.1
    applied 86f9021787... babl: upgrade 0.1.102 -> 0.1.104
    applied b54c944927... gensio: upgrade 2.6.2 -> 2.6.4
    applied 47e945ffd4... libopus: upgrade 1.3.1 -> 1.4
    applied 2172187097... network-manager-applet: upgrade 1.30.0 -> 1.32.0
    applied f2d696e3fc... networkmanager: upgrade 1.42.4 -> 1.42.6
    applied da6d2e4141... opencl-headers: upgrade 2023.02.06 -> 2023.04.17
    applied 8286524f1f... c-periphery: upgrade 2.4.0 -> 2.4.1
    applied 33852a1f26... mbw: upgrade 1.5 -> 2.0
    applied cad5921c78... libmodule-build-tiny-perl: upgrade 0.039 -> 0.043
    applied 416c6168bb... python3-periphery: upgrade 2.3.0 -> 2.4.1
    applied ee38717082... python3-astroid: upgrade 2.15.2 -> 2.15.3
    applied 0a08431bf7... python3-diskcache: upgrade 5.5.1 -> 5.6.1
    applied 28b0ca2785... python3-engineio: upgrade 4.4.0 -> 4.4.1
    applied 953c406dcb... python3-soupsieve: upgrade 2.4 -> 2.4.1
    applied 2ba3867591... python3-google-api-python-client: upgrade 2.85.0 -> 2.86.0
    applied c916e99b50... python3-mock: upgrade 5.0.1 -> 5.0.2
    applied 353982a14e... python3-pyalsaaudio: upgrade 0.9.2 -> 0.10.0
    applied a4828449a3... python3-icu: upgrade 2.10.2 -> 2.11
    applied e41eb35a2c... python3-pymisp: upgrade 2.4.170 -> 2.4.170.1
    applied 4a1e88b75a... python3-python-vlc: upgrade 3.0.18121 -> 3.0.18122
    applied 495557be28... python3-sentry-sdk: upgrade 1.19.1 -> 1.20.0
    applied 5629cd6bca... python3-pyscaffold: upgrade 4.4 -> 4.4.1
    applied 429fd951bc... python3-websockets: upgrade 11.0.1 -> 11.0.2
    applied 59c3093ac1... python3-tornado: upgrade 6.2 -> 6.3
    applied 34153d91b4... redis: upgrade 7.0.10 -> 7.0.11
    applied 4a59976e97... python3-xmlschema: upgrade 2.2.2 -> 2.2.3
    applied 643386c673... samba: upgrade 4.18.1 -> 4.18.2
    applied c1db4cdc68... ser2net: upgrade 4.3.11 -> 4.3.12
    applied da78900c0c... sip: upgrade 6.7.8 -> 6.7.9
    applied 0804e61bd7... polkit: update SRC_URI
    applied 9b32d9b1e9... webp-pixbuf-loader: update 0.2.0 -> 0.2.4
    applied 0b9305faa2... apache2: upgrade 2.4.56 -> 2.4.57
    applied e66ae31c95... lcov: Fix Perl Path
    applied 38f13205ea... lcov: Upgrade 1.14 -> 1.16
    applied 2e0f267504... lcov: Fix homepage
    applied 671c0eb92b... openocd: 0.11->0.12
    applied c527e95d26... openocd: fix jimtcl url
    applied a6738ea35b... openocd: enable jtag-vpi and buspirate
    applied 583190fb9a... python3-pyzstd: add new recipe
    applied 4a9f3bfa22... udisks2: add PACKAGECONFIGs for btrfs,lvm2 and lsm
    applied 647468e3e1... python3-click: Fix ptest failure
    applied 27bdecd1bc... meta-networking/licenses/netperf: remove unused license
    applied 72af3a0acb... pipewire: update 0.3.68 -> 0.3.70
    applied c5f330bc9a... glfw: add packageconfig and wayland dependencies
poky 0907793d5e -> cce6db2a59:
    applied ef12246e32... llvm: remove redundant CMake variables
    applied 65ee49e1e7... libgit2: clean up CMake variables
    applied 899ec32f42... webkitgtk: clean up Python variables
    applied 5a34ddf76d... lib/oe/gpg_sign.py: Avoid race when creating .sig files in detach_sign
    applied f67258fcbf... oeqa/loader: Ensure module names don't contain uppercase characters
    applied 4d2c6baba5... oeqa/selftest/cases/runqemu: update imports
    applied ed363d0ec9... oeqa/targetcontrol: fix misspelled RuntimeError
    applied 6ae5bd896a... oeqa/targetcontrol: do not set dump_host_cmds redundantly
    applied fbd4843544... oeqa/targetcontrol: remove unused imports
    applied c27a505f58... oeqa/utils/commands: fix usage of undefined EPIPE
    applied a5f848f0e0... oeqa/utils/commands: remove unused imports
    applied ff7b3d6810... oeqa/utils/qemurunner: replace hard-coded user 'root' in debug output
    applied 6ef891415f... oeqa/utils/qemurunner: limit precision of timing debugging output
    applied 4651c42cab... oeqa/utils/qemurunner: fix undefined TimeoutExpired
    applied d59756912c... oeqa: whitespace and indentation cleanups
    applied 15dc92a4b1... cve-update-nvd2-native: new CVE database fetcher
    applied 0d099fa404... cargo_common.bbclass: Support local github repos
    applied ddf65370a9... cargo_common.bbclass: add support of user in url for patch
    applied da1bcf0808... devtool: add support for multiple git url inside a cargo based recipe
    applied 11180fd528... patch: support of git patches when the source uri contained subpath parameter
    applied ad460bb6aa... meta-selftest: provide a recipe for zvariant
    applied 476890160a... cargo-update-recipe-crates: force name overrides
    applied bf4b5bd0bd... zvariant: Exclude from world for now to avoid reproducibility issues
    applied edd4fe8cb3... selftest: imagefeatures.py: don't mix tabs and spaces for indentation
    applied 34aa323f18... selftest: runqemu: better check for ROOTFS: in the log
    applied 36f736bd39... selftest: runqemu: use better error message when asserts fail
    applied 3ee55fb694... harfbuzz: depend on glib-2.0-native
    applied b75dd468ae... json-glib: depend on glib-2.0-native
    applied ac3ab46c11... libgudev: depend on glib-2.0-native
    applied 13cc2d67e7... at-spi2-core: depend on glib-2.0-native
    applied 1c3c56ca19... oeqa/runtime: clean up deprecated backslash expansion
    applied 6fbae6e06c... avahi: add missing dependencies
    applied 3c7f0d2ec6... shadow: Fix can not print full login timeout message
    applied 66f7944f9e... python3: Fix failing sysconfig.py test on x86(64 bit) using lib64 as baselib by updating test_sysconfig for posix_user purelib
    applied c8b7c5ab1e... manuals: update disk space requirements
    applied 71b964b0dc... manuals: add rm_work disk space data
    applied 88b440af71... manuals: add minimum RAM requirements
    applied d7f0d97d43... ref-manual: release-process.rst: update testing section
    applied f7b881c7a8... ref-manual: release-process.rst: major updates
    applied 3525a67b0c... manuals: add "LTS" term
    applied 26cfcb7b2d... kernel-dev: fix typos
    applied 658728a678... ref-manual: classes.rst: fix typo
    applied 3f0acc2a61... runqemu: respect IMAGE_LINK_NAME
    applied cd9526df73... rust: do not run separate build/install steps
    applied d75a58d013... rust: install llvm item only once
    applied 6cfa4e540c... rust: update 1.67.1 -> 1.68.1
    applied 93196f698a... report-error: catch Nothing PROVIDES error
    applied 6cce262cc4... graphene: add gobject-types PACKAGECONFIG
    applied af9398b86f... python3-pygobject: depend on gobject-introspection
    applied 497707c404... gconf: add missing dependencies
    applied 8fecd64f26... webkitgtk: add missing dependencies
    applied 3840c0b790... libnotify: depend on glib-2.0-native
    applied 6468b9aa88... classes-recipe/setuptools3-base: clean up FILES assignments
    applied 04108d9c9f... bind: don't package non-existant .la files into -staticdev
    applied 97986cbfc2... gstreamer1.0-plugins: package the internal libraries explicitly
    applied bbf2e79f88... bitbake: fetch2: Display all missing checksum at once
    applied bf2d2d0a62... vte: depend on glib-2.0-native
    applied bcf8ac1ff5... Increase minimum GCC version to 8.0
    applied c097180d43... xdg-utils: Add a patch for CVE-2020-27748
    applied 9b070654f8... cve-extra-exclusions.inc: Exclude some issues not present in linux-yocto
    applied 38e3769a72... sanity.bbclass: Update minimum gcc version to 8.0
    applied 0e5bdb623b... xdg-utils: Fix CVE number
    applied b8bfd3b01b... cve-extra-exclusions: ignore inapplicable linux-yocto CVEs
    applied f5fc2acb4e... qemu: make tracetool-generated output reproducible
    applied e36aa2418f... qemu: retain default trace backend if 'ust' is not enabled
    applied bb1cd7e0ca... qemu: rename deprecated --enable-trace-backend configure option
    applied 53a1ad0c88... oeqa/selftest/bblogging: uncomment python stdout checks
    applied 18e45a9858... busybox: move hwclock init earlier in startup
    applied fd0de1368e... bitbake: bitbake: Bump to version 2.4.0
    applied eb7dfa68b2... build-appliance-image: Update to master head revision
    applied 5f3499c659... poky.conf: Bump version for 4.2 mickledore release
    applied 08d564bd92... build-appliance-image: Update to master head revision
    applied b92918eb0e... bitbake: fetch2/crate: create versioned 'name' entries
    applied 46dafcedf9... cargo-update-recipe-crates.bbclass: Do not add name= to crate:// URIs
    applied 7018774cf6... python3-cryptography-crates.inc: regenerate with updated bbclass
    applied b4c6e1af8c... python3-bcrypt-crates.inc: regenerate with updated bbclass
    applied f135a26aa3... selftest: efibootpartition.py: fix QEMU_USE_KVM usage
    applied bcf6c5483b... xz: upgrade 5.4.1 -> 5.4.2
    applied 8384b32422... grep: upgrade 3.9 -> 3.10
    applied df736bbb51... devicetree.bbclass: fix typo
    applied 5ecafc3fec... oeqa ping.py: avoid busylooping failing ping command
    applied 3083993c71... oeqa ping.py: fail test if target IP address has not been set
    applied c9f2486c52... cpio: Fix wrong CRC with ASCII CRC for large files
    applied 33e23d4992... cve-extra-exclusions: ignore inapplicable linux-yocto CVEs
    applied 311c76c8e8... manuals: improve and fix target for supported distros
    applied 09bdad16f3... build-appliance-image: Update to master head revision
    applied b22f81bc6f... cve-exclusions_6.1: ignore patched CVE-2022-38457 & CVE-2022-40133
    applied 8bda92936b... cve-extra-exclusion: ignore disputed CVE-2023-23005
    applied f79046d082... cve-exclusions: Document some further linux-yocto CVE statuses
    applied 476c25f200... ffmpeg: update 5.1.2 -> 6.0
    applied 89e29cf2e1... u-boot: Upgrade to 2023.04
    applied e79fd53d0a... gobject-introspection: reduce dependencies
    applied 56b8b8a867... at-spi2-core: update 2.46.0 -> 2.48.0
    applied d5592877fe... logrotate: add ptest support
    applied 18b04f9c3f... wic: use part_name when defined
    applied a60925d00a... selftest: wic: Add test for --part-name argument
    applied 73f1b93e7d... libnotify: remove dependency dbus
    applied b44a87156d... python3-psutil: fix-up -tests runtime dependencies
    applied b85f62ba30... e2fsprogs: Define 64bit off_t on rv32
    applied e6cb422333... ffmpeg: Disable asm and rvv on riscv32
    applied 9200d01057... cargo: Fix build on musl/riscv
    applied a04b0eaa38... musl: Update to latest trunk
    applied af9cb6b4cc... apr: upgrade 1.7.2 -> 1.7.3
    applied f0f4ed9ba5... bind: upgrade 9.18.12 -> 9.18.13
    applied 2cb34218f6... cracklib: upgrade 2.9.10 -> 2.9.11
    applied 9210079aac... libhandy: upgrade 1.8.1 -> 1.8.2
    applied 992987cf52... libpcap: upgrade 1.10.3 -> 1.10.4
    applied 6ee7eb3e01... libsdl2: upgrade 2.26.3 -> 2.26.5
    applied aeb61cc313... libsoup: upgrade 3.2.2 -> 3.4.0
    applied e4ad4ebd68... mpg123: upgrade 1.31.2 -> 1.31.3
    applied 596d9eb5cf... acpica: upgrade 20220331 -> 20230331
    applied 63903b3b1a... ccache: upgrade 4.7.4 -> 4.8
    applied 93809a4028... libcap: upgrade 2.67 -> 2.68
    applied 695552afa4... man-pages: upgrade 6.03 -> 6.04
    applied 7ee4f1cb5d... mtools: upgrade 4.0.42 -> 4.0.43
    applied 70a069093e... pango: upgrade 1.50.13 -> 1.50.14
    applied d1c86d713e... ruby: upgrade 3.2.1 -> 3.2.2
    applied bf2fa5bf8b... spirv-headers: upgrade 1.3.239.0 -> 1.3.243.0
    applied 41b91c6956... spirv-tools: upgrade 1.3.239.0 -> 1.3.243.0
    applied 3c499ac5a3... sqlite3: upgrade 3.41.0 -> 3.41.2
    applied deb8f527ba... texinfo: upgrade 7.0.2 -> 7.0.3
    applied ed9e8941f4... wayland: upgrade 1.21.0 -> 1.22.0
    applied 862bfce832... wpebackend-fdo: upgrade 1.14.0 -> 1.14.2
    applied 163c9ffb9b... xserver-xorg: upgrade 21.1.7 -> 21.1.8
    applied 42badb5444... xwayland: upgrade 22.1.8 -> 23.1.1
    applied 94d818760d... vala: upgrade 0.56.4 -> 0.56.6
    applied bd346a9eca... python3-cython: upgrade 0.29.33 -> 0.29.34
    applied f9f1eeece4... python3-hypothesis: upgrade 6.68.2 -> 6.71.0
    applied 46e219de63... python3-importlib-metadata: upgrade 6.0.0 -> 6.2.0
    applied 8d4149f232... python3-installer: upgrade 0.6.0 -> 0.7.0
    applied 961e16a132... python3-markdown: upgrade 3.4.1 -> 3.4.3
    applied 7a5fb2122d... python3-pathspec: upgrade 0.11.0 -> 0.11.1
    applied 45b7594b1f... python3-pygobject: upgrade 3.42.2 -> 3.44.1
    applied b61233e179... python3-pyopenssl: upgrade 23.0.0 -> 23.1.1
    applied b205ab58a6... rust: Upgrade 1.68.1 -> 1.68.2
    applied 1419a694ac... python3-pytz: upgrade 2022.7.1 -> 2023.3
    applied 346bf4e814... python3-setuptools: upgrade 67.6.0 -> 67.6.1
    applied 2ac329445c... linux-firmware: upgrade 20230210 -> 20230404
    applied 25f6334feb... systemd: Refresh a musl patch to remove patch-fuzz with 253.3
    applied 042d94dce8... mesa: upgrade 23.0.0 -> 23.0.2
    applied 03395abc2c... kernel-fitimage: Fix the default dtb config check
    applied 2c9488e5d2... tiff: Add fix for CVE-2022-4645
    applied 2368c2c884... kernel-devsrc: depend on python3-core instead of python3
    applied 6406677e92... ref-manual: variables: document VOLATILE_TMP_DIR
    applied 00d9f298b0... migration-guides: update 4.2 migration and release notes
    applied 066f44b161... bitbake: event: add bb.event.ParseError
    applied a99566dac1... bitbake: bitbake: ConfHandler: Allow variable flag name with a single character
    applied ba94f9a3b1... bitbake: runqueue: fix PSI check calculation
    applied 9f96e49468... meta/recipes: ensure all recipes have a SUMMARY
    applied fa56412806... libarchive: Enable acls, xattr for native as well as target
    applied 493e0eae7f... populate_sdk_ext.bbclass: set METADATA_REVISION with an DISTRO override
    applied c9205c3bfd... libpam: Fix the xtests/tst-pam_motd[1|3] failures
    applied 378dddd7a3... cve-update-nvd2-native: added the missing http import
    applied 1a5d7fa527... musl-locales: Add Canadian French (fr_CA) locale support
    applied 2f958e043a... patch.py: Use shlex instead of deprecated pipe
    applied 1d70f5b466... package: Use shlex instead of deprecated pipe
    applied 82ee2dc94b... python3-pyproject-hooks: add missing run-time dependencies
    applied 3c12f99c35... python3-packaging: add missing run-time dependencies
    applied 28b08e55b3... python3-manifest: add tomllib
    applied a3ff0f2d4b... python3-manifest: add ensurepip
    applied ff633ce7a7... python3-build: add missing run-time dependencies
    applied d8e9c1c049... systemd: upgrade 253.1 -> 253.3
    applied 67e22b9fc9... oeqa/selftest: Use SSTATE_DIR of parent build dir
    applied 150464e2ff... oeqa/utils/metadata.py: Fix running oe-selftest running with no distro set
    applied 01f0a371b1... kernel: improve initramfs bundle processing time
    applied 66eab8234c... gawk: Disable known ptest fails on musl
    applied 50cceeb627... gawk: Remove redundant patch
    applied 2e2450a704... gawk: Add skipped.txt to emit test to ignore
    applied 77b5567f18... libxml2: Disable icu tests on musl
    applied 6ba9422665... libgit2: upgrade 1.6.3 -> 1.6.4
    applied 8457590f9f... libsolv: upgrade 0.7.23 -> 0.7.24
    applied f3f38e2c80... libxml2: upgrade 2.10.3 -> 2.10.4
    applied 49abe28bba... boost: upgrade 1.81.0 -> 1.82.0
    applied 7c582c805d... ofono: upgrade 2.0 -> 2.1
    applied afa28c7e17... python3-dtschema: upgrade 2023.1 -> 2023.4
    applied 5f2b568c89... python3-packaging: upgrade 23.0 -> 23.1
    applied bc9b1df26f... python3-pytest: upgrade 7.2.2 -> 7.3.1
    applied 1cca2202bf... stress-ng: upgrade 0.15.06 -> 0.15.07
    applied d84eb2a5e4... scripts/rpm2cpio.sh: Use bzip2 instead of bunzip2
    applied c1e24cee0e... scripts/runqemu: Add possibility to disable network
    applied 78ddb9f87e... machine/qemuarm*: don't explicitly set vmalloc
    applied 22fc34613b... report-error: make it catch ParseError error
    applied ef16919e98... shadow: backport patch to fix CVE-2023-29383
    applied 6fedd43f96... apt-util: Fix ptest on musl
    applied 1a1025658c... bitbake: npmsw fetcher: Avoid instantiating Fetch class if url list is empty
    applied cbae80ec40... bitbake: cooker: do not abort on single ctrl-c
    applied c020160248... bitbake: bitbake-user-manual: document BB_CACHEDIR
    applied 433a90204c... bitbake: bitbake-user-manual: add addpylib and BB_GLOBAL_PYMODULES
    applied bfa9338b57... bitbake: bitbake-user-manual: add BB_HASH_CODEPARSER_VALS
    applied df6dbc5776... migration-guides: add release-notes for 4.0.9
    applied 84a9d5e09b... ref-manual: add new SDK_ZIP_OPTIONS variable
    applied f64e767e83... ref-manual: Add new RUST_CHANNEL variable
    applied 37f0bc3701... ref-manual: update for IMAGE_MACHINE_SUFFIX addition
    applied 62031fbfce... dev/ref-manual: Remove references to INC_PR
    applied f901224f88... ref-manual: add BB_CACHEDIR
    applied 8242bd30de... migration-guides: Add coverage of addpylib directive
    applied 356b6f0e32... ref-manual: Remove references to package_tar class
    applied 216b0af07e... ref-manual: add missing QA checks from previous releases
    applied d2852faef4... ref-manual: document new patch-status-* QA checks
    applied d469b1fae0... ref-manual: add FIT_CONF_DEFAULT_DTB
    applied bc18257617... ref-manual: add section link also to buildtools-extended entry
    applied f961d5f73e... ref-manual: add SDK_ARCHIVE_TYPE
    applied 5a8e2d41a6... ref-manual: move Initramfs entry from variables to terms
    applied 7508711b38... dev/ref-manual: Document INIT_MANAGER
    applied 57bf1f17d7... migration-guides: extend migration guide for 4.2
    applied 86b1247db4... release-notes-4.1: fix some CVE links
    applied 63bd5762b4... release-notes-4.2: add release notes
    applied 5323e885bc... screen: backport fix for CVE-2023-24626
    applied 5a944d32a1... go: backport fix for CVE-2023-24537
    applied 405feecef8... release-notes-4.2: update RC3 changes
    applied de71f28d9f... bitbake: bitbake-user-manual: fix BB_RUNFMT's default value
    applied 828fe1c39a... linux-yocto/6.1: update to v6.1.23
    applied 2e8b28d98e... linux-yocto/5.15: update to v5.15.106
    applied 22cae3525a... linux-yocto/6.1: update to v6.1.24
    applied 50d461df73... linux-yocto/5.15: update to v5.15.107
    applied a769ebbd5f... linux-yocto/6.1: update to v6.1.25
    applied 42acfb14bd... linux-yocto/5.15: update to v5.15.108
    applied 074b39e7d5... coreutils: Delete gcc sysroot parameter for ptest on target
    applied aab8d5b6a4... lua: Disable locale dependent tests on musl
    applied 6f45ae15f2... attr: Disable attr.test on musl
    applied 4bbf473b64... acl: Disable misc.test on musl
    applied a83f1f289d... fts: Fix typo in summary
    applied cce022a507... cmake: add CMAKE_SYSROOT to generated toolchain file
    applied dd317ae2a0... m4: Do not munge locale in ptests for musl
    applied 24f1964fcd... gdb: Fix conflict of sframe-spec.info
    applied ef577b03d7... wic/bootimg-efi: if fixed-size is set then use that for mkdosfs
    applied 8fba302211... cve-extra-exclusions: linux-yocto: ignore fixed CVE-2023-1652 & CVE-2023-1829
    applied 6f71ce8214... ref-manual: classes.rst: document devicetree.bbclass
    applied 86d9c4cb2a... ref-manual: remove unused and obsolete file
    applied c48e088682... ref-manual: variables.rst: add wikipedia shortcut for "getty"
    applied aa6c2cc60e... overview-manual: update section about source archives
    applied 9b6a25606e... manuals: document SPDX_CUSTOM_ANNOTATION_VARS
    applied a9bd0f690e... overview-manual: development-environment: update text and screenshots
    applied 59f7a0ee5a... ref-manual: add "Mixin" term
    applied c621743c13... migration-guides: release-notes-4.0.9.rst: add missing SPDX info
    applied 7f39a583e7... migration-guides: fixes and improvements to 4.2 release notes
    applied b01a12a135... manuals: expand init manager documentation
    applied cce6db2a59... ref-manual: variables.rst: document KERNEL_DANGLING_FEATURES_WARN_ONLY
meta-raspberrypi 3afdbbf782 -> bf948e0aa8:
    applied 2ad4dd667a... recipe-bsp: Add support for Raspberry Pi Camera Module v3
    applied 56fba81e37... docs: Update extra build config Raspberry Pi Camera Module section
    applied bf948e0aa8... python3-adafruit-blinka: Fix the correct python recipes path in dynamic-layer sub-dir
meta-arm 9b6c8c95e4 -> c60d7865dd:
    applied 91725e95c9... arm-bsp/n1sdp-board-firmware: update to newer SHA
    applied b3c60cd3fa... arm-bsp/optee-os: N1SDP support for optee-os 3.20
    applied 9e57aa4f50... CI: dev kernel allow failure
    applied 3b4ab43d2f... arm/linux-yocto: remove IP_VS config fragment
    applied 50e74acd97... arm-bsp/optee: Update OP-TEE TA devkit to 3.20 for N1SDP
    applied d2661fa7c0... arm-bsp/corstone1000: tf-m set/get fwu, private metadata using gpt
    applied 794c7bfd12... arm/scp-firmware: add recipe for 2.11
    applied 0e5f5ac81f... arm-bsp/scp-firmware: move all machines to SCP 2.11
    applied 5a62ce8561... arm/scp-firmware: remove 2.10 recipe
    applied 8acd61c427... CI: update to the latest kas version
    applied 8f62e0bff8... optee-os-tadevkit: remove old unused patches
    applied 32908f1f9e... optee-client: add 3.20.0 version
    applied 3a7f746057... optee-test: add 3.20.0 version
    applied 1f2e4e7ff5... optee-examples: add 3.20.0 version
    applied 5da8393712... arm-bsp/n1sdp: use edk2-firmware 202211 version
    applied efa053885f... CI: track mickledore branch
    applied 0b528b731a... arm/scp-firmware: Add support for components other than SCP, MCP
    applied 323362f682... arm-bsp/trusted-firmware-m: apply patches correctly from external repos
    applied 524203dc17... arm-bsp/trusted-firmware-m: Switch to TF-M BL1 in Corstone1000
    applied f54a9f37eb... arm-bsp/corstone1000: add OTP config for fvp
    applied 173c9d887e... arm-bsp/tc1: Fix signed u-boot
    applied 2d8bc0be8e... arm-bsp/tc1: Add FVP support
    applied a46ddc804e... arm/trusted-firmware-m: add the tf-m-extras repository that some machines need
    applied 387465c622... arm/trusted-firmware-m: clean up environment flags
    applied 1596147a84... arm/trusted-firmware-m: package .elf files in PN-dbg
    applied a091d49db1... arm-bsp/trusted-firmware-m: enable for Total Compute on RSS
    applied 6405018ced... arm/trusted-firmware-m-scripts: relocate to tfm directory
    applied ea407ce849... CI: add TF-M to TC build
    applied b3c7b2d7a5... CI: Remove ts-smm-gateway from N1SDP
    applied 95e535b0a1... arm-bsp/trusted-firmware-m: Increase assets number for corstone1000
    applied 7f0c57f7c6... arm-bsp/trusted-firmware-a: Update N1SDP to v2.8.0
    applied c60d7865dd... arm-bsp/tc1: disable signed kernel image

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog