### PR TITLE
subtree update

### DIFF
--- a/dunfell.conf
+++ b/dunfell.conf
@@ -92,7 +92,7 @@ last_revision = 168440a0f1c89fc8ef6cabea033c5611d323df89
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = dunfell
-last_revision = 7007d14c2558f86a49c2e2acb6154432c2ba4092
+last_revision = 116bfe8d5e5851e7fc5424f40da8691a19c5b5ee
 
 [meta-openpower]
 src_uri = https://gerrit.openbmc-project.xyz/openbmc/meta-openpower
@@ -158,5 +158,5 @@ last_revision = 7eef85ee0d2e6f8100c06c0f9a9cb52c941ecd50
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = dunfell
-last_revision = a631bfc3a38f7d00b2c666661a89a758a0af9831
+last_revision = 733d919af4714845c3a3d64d60c24874881077b3
 

--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 5cbe3041befbf4cd588e8f45a793448833cc3f64
+last_revision = 3fcafa3a945aa57d58ca4f1a0f6d20280df7cdbd
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 829dcb63f01651750a56e2a3d21635e53199af38
+last_revision = def4759e95fc8e20272fb337ac349c2fddab357e
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 9240ea91caaf82501b80af7bfc94673a3dfdaae5
+last_revision = 8e07f0d328d4aa573bdb1f89cff853ce12602356
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = 5c2379f4bc5f0e3972f8798fbe45e9266c867433
+last_revision = 180dac9aece2f9ae50566762103c2088e0b868fd
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 76494f2b66003b0ff3b26882435107ef0ac060ba
+last_revision = 00f3d5806456f3814eb909eb96a85ceeeaba01e5
 


### PR DESCRIPTION
- subtree update: 8474749997 -> bd433b6083
- openbmc-subtree: add support for sh-2.x
- mickledore: set meta-raspeberrypi to mickledore branch
- subtree update: e760df85ed -> 64026a4906
