### PR TITLE
subtree update: 59c98f4cab -> e8dfee9d0e

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 3fcafa3a945aa57d58ca4f1a0f6d20280df7cdbd
+last_revision = d6fac49541cee5b809003ed8e7c5e80c0529e163
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = def4759e95fc8e20272fb337ac349c2fddab357e
+last_revision = 2638d458a57f293c5926ddd5b6b291d14c218c4e
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 8e07f0d328d4aa573bdb1f89cff853ce12602356
+last_revision = dff85b9a9f66002856b9ed3b1aa3a384c0bc43d9
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = 180dac9aece2f9ae50566762103c2088e0b868fd
+last_revision = 405cca40288d1c44f8cba12513f72dc578364313
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 00f3d5806456f3814eb909eb96a85ceeeaba01e5
+last_revision = 13b646c0e167ca52f69c91be5538049b172015ac
 


### PR DESCRIPTION
meta-arm 3fcafa3a94 -> d6fac49541:
    applied ba93470738f1... trusted-firmware-a: update to the latest TF-A LTS
    applied 088c6825f55b... arm-bsp/tc1: update to use the latest tf-a
    applied f7e551e47988... arm/trusted-firmware-m: remove -fcanon-prefix-map from DEBUG_PREFIX_MAP
    applied 18be955c9a43... arm-bsp/external-system: remove -fcanon-prefix-map from DEBUG_PREFIX_MAP
    applied f83c4abdbdc8... arm-toolchain/external-arm: remove -fcanon-prefix-map from DEBUG_PREFIX_MAP
    applied 7abee726702f... arm/scp-firmware: use concerete toolchain
    applied 980f37d4d3d8... arm-toolchain/gcc-arm-12.2: remove
    applied 4b3ef7bf849c... arm-bsp/u-boot: corstone1000: upgrade NVMXIP support
    applied 69b4910f755b... arm/scp-firmware: update to v2.12.0
    applied 0943562aa045... optee-os: do not explicitly set CFG_MAP_EXT_DT_SECURE=y
    applied 856610082bb1... gn: update to latest
    applied 770bef8dced4... gn: Fix build with gcc13
    applied e6301496ce84... external-arm-toolchain: Enforce absolute path check
    applied 533cbfd10b56... arm/gn: fix build with GCC <13
    applied 60abe4647406... CI: always put the build logs in an artifact
    applied 782ea3cd1688... CI: print the name of the documentation when building
    applied 1cdc2fc2fbb4... arm-bsp/u-boot: corstone1000: Fix EFI multiple protocol install failure
    applied 8a014d897876... arm-bsp/u-boot: corstone1000: Enable EFI set/get time services
    applied fa6e20d33b09... arm-bsp/trusted-services: corstone1000: GetNextVariableName Fix
    applied c99ed29ba6cf... arm-bsp/optee-os:corstone1000: Drop SPMC non secure interrupt patches
    applied 8cd16aabdbe8... arm-bsp/u-boot: corstone1000: Fix u-boot compilation warnings
    applied 6b1bf55b942d... arm-bsp/trusted-services: corstone1000: Fix PSA_RAW_KEY agreement test
    applied 7714ad8f552c... arm-bsp/trusted-services: corstone1000: Fix Capsule Update
    applied d6fac49541ce... arm-bsp/trusted-firmware-a: corstone1000: Fix Trusted-Firmware-A version for corstone1000
meta-openembedded def4759e95 -> 2638d458a5:
    applied 586a4bfbacc7... meta-python: Add stopit
    applied 8d38aec39c1f... uutils-coreutils: upgrade 0.0.18 -> 0.0.19
    applied ecdbd141dd2b... glog: Correct the packaging of /usr/share/glog/cmake/FindUnwind.cmake
    applied c07fe3639a48... lmsensors: do not pull in unneeded perl modules for run-time dependencies
    applied 47e2b5fb0fea... cukinia: remove trailing whitespaces
    applied daf73e7279da... cukinia: upgrade 0.6.1 -> 0.6.2
    applied 97c9e5c38d87... cukinia: inherit allarch
    applied deaa4c111fd3... cukinia: add libgpiod-tools to RRECOMMENDS
    applied aceaf2bfdaa9... mpich: Upgrade to 4.1.1
    applied 93a42f19bdc1... meta-oe: add pahole to NON_MULTILIB_RECIPES
    applied 54885a5af2da... grpc: point to the native protobuf compiler binary
    applied 985964617453... ply: Demand BFD linker explicitly
    applied 3c2ce936fefb... crucible: Upgrade to 2023.04.12 release
    applied 812f091414b3... python3-stopit: add missing run-time dependencies
    applied 0eed75ff15f0... php: drop explicite ARM_INSTRUCTION_SET
    applied 202bd4f46687... schroedinger: Fix building tests
    applied b802655e1309... fwts: Fix build issues found with lld linker
    applied 1ae57e285bbe... xfce4-sensors-plugin: Use bfd linker instead of lld
    applied 1b7c92fa9e20... ostree: Fix build errors found with lld linker
    applied a97b97bdaaaa... spice-gtk: Fix build with lld linker
    applied fd3807c8f8f2... sblim-sfcb: Fix build with lld linker
    applied 80e8c93c8272... ctags: upgrade 6.0.20230604.0 -> 6.0.20230611.0
    applied d36ee7a9b1e8... gjs: upgrade 1.76.0 -> 1.76.1
    applied a0b670cdacb1... ipcalc: upgrade 1.0.2 -> 1.0.3
    applied 8f0230b9d407... libadwaita: upgrade 1.3.2 -> 1.3.3
    applied d0ee155ce026... libjcat: upgrade 0.1.13 -> 0.1.14
    applied 7b7d5c3e0a23... libqb: upgrade 2.0.6 -> 2.0.7
    applied ed0b5b03e4a5... mbpoll: upgrade 1.5.0 -> 1.5.2
    applied aec502ac8485... mpich: upgrade 4.1.1 -> 4.1.2
    applied e284543c4eca... nautilus: upgrade 44.2 -> 44.2.1
    applied d2a38a5ec52e... ntp: upgrade 4.2.8p16 -> 4.2.8p17
    applied 092c35dfaadb... python3-eth-account: upgrade 0.8.0 -> 0.9.0
    applied 4ca5c469d66a... python3-eth-hash: upgrade 0.5.1 -> 0.5.2
    applied 0413f01a424e... python3-eth-typing: upgrade 3.3.0 -> 3.4.0
    applied ab16a3ac7eb9... python3-eth-utils: upgrade 2.1.0 -> 2.1.1
    applied c2dfc571db81... python3-platformdirs: upgrade 3.5.1 -> 3.5.3
    applied 8ed3dea40ba5... pcsc-lite: upgrade 1.9.9 -> 2.0.0
    applied d6c5cb3d4f81... php: upgrade 8.2.6 -> 8.2.7
    applied 3ab34152a04f... python3-argcomplete: upgrade 3.0.8 -> 3.1.0
    applied 3207049cd64f... python3-autobahn: upgrade 23.1.2 -> 23.6.1
    applied 0e409b3ceddf... python3-cassandra-driver: upgrade 3.27.0 -> 3.28.0
    applied 49ae33aba52e... python3-cmake: upgrade 3.26.3 -> 3.26.4
    applied 0347cd1b9712... python3-django: upgrade 4.2.1 -> 4.2.2
    applied 1147abcc0cc6... python3-hexbytes: upgrade 0.3.0 -> 0.3.1
    applied 73d5dab91db5... python3-imageio: upgrade 2.30.0 -> 2.31.0
    applied a7a11d2ec6ec... python3-pykickstart: upgrade 3.47 -> 3.48
    applied 3f92f3166983... python3-pymisp: upgrade 2.4.171 -> 2.4.172
    applied 644f43be64f0... python3-pymodbus: upgrade 3.3.0 -> 3.3.1
    applied 36f4f6149cfa... python3-sentry-sdk: upgrade 1.25.0 -> 1.25.1
    applied f09cd0dfec30... python3-websocket-client: upgrade 1.5.2 -> 1.5.3
    applied fc0c26d04442... python3-zeroconf: upgrade 0.63.0 -> 0.64.1
    applied 782dd040da70... remmina: upgrade 1.4.30 -> 1.4.31
    applied 2352915607f0... tio: upgrade 2.5 -> 2.6
    applied d613875f540f... open62541: add multithreading PACKAGECONFIG option
    applied f8f47d573226... open62541: allow disabling subscriptions
    applied c6581c7179d6... gnome-software: upgrade 44.1 -> 44.2
    applied 3c9494fb772b... redis: use the files path correctly
    applied 91e2bfb17fb4... python3-meson-python: New recipe
    applied 1baf66e09b70... python_mesonpy: New class
    applied 99991e08f511... opengl-es-cts: 3.2.8.0 -> 3.2.9.3
    applied eb6de6cd4bd5... libtracefs: upgrade 1.6.4 -> 1.7.0
    applied 9c2602353bb8... libtracefs: Fix build with clang+musl
    applied ce00fecc95b4... zeromq: consider license exception over LGPL-3.0
    applied 45a8bb2620b6... libgpiod: modify test 'gpioset: toggle (continuous)'
    applied d04c39d753ef... ntpd: switch service type from forking to simple
    applied a1dfcaeb5988... python3-stopit: fix override syntax
    applied f0cd4aca2018... opencv: Fix for CVE-2023-2617
    applied f8df47347619... python3-sqlparse: fix CVE-2023-30608
    applied 051c15a36d87... gosu: Upgrade to 1.16 release
    applied c1f86dac48e9... layers: Move READMEs to markdown format
    applied 79d5e2bbe403... libplist_2.3.0: compile fix for version
    applied ceff4a5263bd... xdg-desktop-portal-wlr: Fix build with older mesa
    applied 3647fd37ecef... geary: Fix build with vala >= 0.56.8
    applied c334ce383f38... libforms: Replace hardcoded dep on mesa with virtual/libgl
    applied 777ad70dbea3... adw-gtk3: upgrade 4.7 -> 4.8
    applied 2fc9fad0eb93... evince: upgrade 44.1 -> 44.2
    applied ed6e34b005f0... gensio: upgrade 2.6.5 -> 2.6.6
    applied 22d129315410... redis-plus-plus: upgrade 1.3.8 -> 1.3.9
    applied 9c7101b1b131... python3-click-repl: upgrade 0.2.0 -> 0.3.0
    applied 299324f671ef... python3-platformdirs: upgrade 3.5.3 -> 3.6.0
    applied 0f622acba7f2... python3-pytest-mock: upgrade 3.10.0 -> 3.11.1
    applied 3cf953e25c49... python3-croniter: upgrade 1.3.15 -> 1.4.1
    applied 5d1701a3d984... python3-elementpath: upgrade 4.1.2 -> 4.1.3
    applied c361dd18ad8f... python3-google-api-core: upgrade 2.11.0 -> 2.11.1
    applied bdebd3cb3bd8... python3-google-api-python-client: upgrade 2.88.0 -> 2.89.0
    applied 908a719151f0... python3-googleapis-common-protos: upgrade 1.59.0 -> 1.59.1
    applied c9f80ccadc30... python3-google-auth: upgrade 2.19.1 -> 2.20.0
    applied 4f702b35f6d2... python3-imageio: upgrade 2.31.0 -> 2.31.1
    applied d48d4a02dc89... python3-protobuf: upgrade 4.23.2 -> 4.23.3
    applied b473fb584dc1... python3-pyproj: upgrade 3.5.0 -> 3.6.0
    applied 21a982008cc5... python3-rich: upgrade 13.4.1 -> 13.4.2
    applied 0d232da6d508... python3-robotframework: upgrade 6.0.2 -> 6.1
    applied 2ec0f463d986... python3-ujson: upgrade 5.7.0 -> 5.8.0
    applied a2adca7a29de... python3-xmlschema: upgrade 2.3.0 -> 2.3.1
    applied 7a277a1b9252... python3-xmodem: upgrade 0.4.6 -> 0.4.7
    applied ed1a754819df... python3-zeroconf: upgrade 0.64.1 -> 0.68.0
    applied 4c8b3a91c664... strongswan: upgrade 5.9.10 -> 5.9.11
    applied 39dfcaceba36... rdfind: upgrade 1.5.0 -> 1.6.0
    applied 63b1dbd093c8... syzkaller: Upgrade to latest tip of trunk
    applied d552fa0478b9... mdns: remove unneeded headers
    applied 9cb5f5c6e916... mbedtls: add support for v3.x
    applied 1aaf1023e0ff... ostree: Upgrade 2023.3 -> 2023.4
    applied a01c94b71b2f... asio: fix malformed Upstream-Status
    applied dd2a100449fa... libgpiod: fix malformed Upstream-Status
    applied 2393cd93ae1b... postfix: fix malformed Upstream-Status
    applied be8c765c7c4e... *.patch: add Upstream-Status to all patches
    applied e3e603f44acb... ristretto: Upgrade to 0.13.1 release
    applied 92fa8f33d20f... postfix: remove 2nd Upstream-Status
    applied 144bc977c7f5... zeromq: consider license exception over LGPL-3.0
    applied 5448c7142258... rasdaemon: upgrade to 0.8.0
    applied d4b37afb7fed... opencv: Revert fix runtime dependencies
    applied c2ad22e09264... python3-pywbemtools: remove build-time dependencies
    applied 364a2f895685... python3-pywbem: drop unneeded class from RDEPENDS
    applied 9f88e84b0c73... python3-pywbem: don't use PYTHON_PN
    applied 170709214595... python3-pywbem: order RDEPENDS alphabetically
    applied 20c64a4a6305... python3-pywbem: add missing run-time dependencies
    applied d2142c4bf679... python3-padatious: add missing run-time dependencies
    applied edffdc715e31... python3-pako: add missing run-time dependencies
    applied be836c011586... python3-paramiko: stop using PYTHON_PN
    applied a0151160bc9c... python3-paramiko: add missing run-time dependencies
    applied 6daa8faf697c... python3-path: fix coding style
    applied 64dccc68b0c5... python3-path: add missing run-time dependencies
    applied d6ad0dae171a... python3-ecdsa: don't install tests
    applied a24e93b575ee... python3-et-xmlfile: fix coding style
    applied 3cecc1ca22c2... python3-et-xmlfile: add missing run-time dependencies
    applied 625818eb0eed... python3-flask-user: fix coding style
    applied e88c3c844012... python3-flask-user: add missing run-time dependencies
    applied ebba7757fdc3... python3-isort: fix coding style
    applied 7d45c76cb4cc... python3-isort: add missing run-time dependencies
    applied 5f2ef328450d... python3-isodate: stop using PYTHON_PN
    applied 33b910b51cea... python3-isodate: add missing run-time dependencies
    applied 12e6ef856487... python-idna-ssl: add missing run-time dependencies
    applied 1659a00086a3... python3-hpack: add missing run-time dependencies
    applied 033392aac057... python3-h11: add missing run-time dependencies
    applied e9d6d0490a10... python3-gsocketpool: drop unneeded DEPENDS
    applied 6e075574569a... python3-gsocketpool: stop using PYTHON_PN
    applied b6304859867a... python3-gsocketpool: add missing run-time dependencies
    applied 21a8212f2619... python3-flask-mail: stop using PYTHON_PN
    applied 741271afd89c... python3-flask-mail: add missing run-time dependencies
    applied cbfa641b94b9... python3-flask-sijax: stop using PYTHON_PN
    applied 785fd8d117c2... python3-flask-sijax: add missing run-time dependencies
    applied 25bb720fe812... python3-flask-script: remove recipe
    applied 2493f4c8addd... python3-aioserial: fix coding style
    applied 54fba67fb462... python3-aioserial: add missing run-time dependencies
    applied 866cfb9bd821... python3-aspectlib: add missing run-time dependencies
    applied 57efc765ba2e... python3-asyncio-throttle: add missing run-time dependencies
    applied 2b75c44967eb... python3-attrdict3: add missing run-time dependencies
    applied 378a1830e8a6... python3-betamax: add missing run-time dependencies
    applied 9d51bf9c9b65... python3-binwalk: add missing run-time dependencies
    applied 8edaa6a92e25... python3-can: fix coding style
    applied ae3bc8d14f19... python3-can: add missing run-time dependencies
    applied 2a0204670f22... python3-click-spinner: add missing run-time dependencies
    applied 23a86793f3c3... python3-colorlog: add missing run-time dependencies
    applied 41c3a34e3700... python3-colorzero: add missing run-time dependencies
    applied 7ed01ba2f0ec... python3-configobj: fix coding style
    applied ab7141aebba7... python3-configobj: add missing run-time dependencies
    applied f839d29ca6cc... python3-configshell-fb: add missing run-time dependencies
    applied 0f74b11f3786... python3-coverage: fix coding style and RDEPENDS
    applied 74e076b277db... python3-custom-inherit: add missing run-time dependencies
    applied b763bcfdbecc... python3-dateparser: fix coding style
    applied 749847ab0507... python3-dateparser: add missing run-time dependencies
    applied f3f3e97ff142... python3-tzlocal: fix coding style
    applied 9f28bbf6a45b... python3-tzlocal: add missing run-time dependencies
    applied fe17742088e8... python3-dbus-next: add missing run-time dependencies
    applied 2951081f72c7... python3-defusedxml: add missing run-time dependencies
    applied a2cbfc7f92e1... python3-setuptools-scm-git-archive: add missing run-time dependencies
    applied 2638d458a57f... unbound: add option to build with libevent
poky 00f3d58064 -> 13b646c0e1:
    applied 5be5b6ee21ba... lighttpd: upgrade 1.4.69 -> 1.4.71
    applied 098df1bd77ac... nettle: rewrite ptest integration
    applied 03b693fd48bd... nettle: inherit lib_package
    applied 10087741166b... glib-2.0: upgrade 2.76.2 -> 2.76.3
    applied 9f1711e8fd6a... spirv-tools: fix INTERFACE_LINK_LIBRARIES cmake prop
    applied bbec9829b1e1... vulkan-validation-layers: add new recipe v1.3.243.0
    applied 0f9d412d421a... go: Upgrade 1.20.4 -> 1.20.5
    applied 7e2199be524e... weston-init: introduce xwayland PACKAGECONFIG
    applied 0241bdb49c52... meta: introduce KCONFIG_CONFIG_ENABLE_MENUCONFIG
    applied 1edd0b41f82e... qemu: Split the qemu package
    applied a776dd266774... linux-yocto/6.1: update genericx86* machines to v6.1.30
    applied 43c23eebc912... dpkg: upgrade to v1.21.22
    applied aa089c8e9fd5... cmake: upgrade to v3.26.4
    applied 9048ceef995c... libubootenv: upgrade 0.3.3 -> 0.3.4
    applied 40e08f21efd2... meta: lib: oe: npm_registry: Add more safe caracters
    applied 01aacb49eaa4... mtd-utils: export headers and libraries for MTD and UBI
    applied 7ff2e05a5b5c... common-licenses: Add LGPL-3.0-with-zeromq-exception
    applied 61db2b4796a2... libwebp: Fix CVE-2023-1999
    applied 96f64c469bb3... llvm: Upgrade to 16.0.5
    applied 177886950ea2... runqemu-gen-tapdevs: Refactoring
    applied d43c41fcaf06... runqemu-ifupdown/get-tapdevs: Add support for ip tuntap
    applied 5016450e123a... baremetal-helloworld: Update SRCREV to fix entry addresses for ARM architectures
    applied eee8bb497f7f... binutils: move packaging of gprofng static lib into common .inc
    applied 7cf7388e707d... weston-init: make sure the render group exists
    applied 2d371c9abf47... weston-init: add weston user to the render group
    applied b74de41bb40b... weston-init: add the weston user to the wayland group
    applied 44f23725b070... psplash: replace Yocto .h by .png splashscreen
    applied 616f694b72c4... glibc: Pass linker choice via compiler flags
    applied d70ff3f5a6d4... libgcc: Always use BFD linker
    applied c4b4a638ba27... cups: Fix CVE-2023-32324
    applied 34d73073a88c... useradd-example: package typo correction
    applied 52edee5ad370... cve-extra-exclusions: add more ignores for 2023 kernel CVEs
    applied d9cf8973d01b... cve-extra-exclusions: remove 2019 blanket ignores
    applied 5776d07bddc0... scripts/runqemu: split lock dir creation into a reusable function
    applied 66b7727577f8... scripts/runqemu: allocate unfsd ports in a way that doesn't race or clash with unrelated processes
    applied 617d2303c061... oeqa/selftest/bbtests: add non-existent prefile/postfile tests
    applied 3a4a789482b7... weston-init: fix the mixed indentation
    applied 3cd202d7df75... weston-init: guard against systemd configs
    applied 8f4b90c0430a... weston-init: add profile to point users to global socket
    applied 5d63d4a08f1b... apmd: remove recipe and apm MACHINE_FEATURE
    applied 6d40da81c1fd... qemu: a pending patch was submitted and accepted upstream
    applied 3156b5715b86... maintainers.inc: unassign Adrian Bunk from wireless-regdb
    applied a1443bd9db14... maintainers.inc: unassign Alistair Francis from opensbi
    applied 7ce0f1263e5b... maintainers.inc: unassign Chase Qi from libc-test
    applied a106c2c12304... maintainers.inc: unassign Oleksandr Kravchuk from python3 and all other items
    applied 4a70c556bf5f... maintainers.inc: unassign Ricardo Neri from ovmf
    applied dc03dac76911... poky-altconfig: enable usrmerge DISTRO_FEATURE
    applied f457f358dfc0... systemd-systemctl: support instance expansion in WantedBy
    applied 3220095b56d0... efivar: Upgrade to tip of trunk
    applied 03b87d72b6a0... babeltrace2: Always use BFD linker when building tests with ld-is-lld distro feature
    applied c26f00fdfa29... spirv-tools: Use baselib instead of base_libdir
    applied ce01aa37bfb1... perl: fix CVE-2023-31484
    applied 970b5b0fa248... gi-docgen: correct comment
    applied abee4e69e114... gobject-introspection: remove obsolete DEPENDS
    applied 155ee00592d6... libstd-rs, rust: use bfd linker instead of gold
    applied 38c0ea3d6638... parted: Add missing libuuid to linker cmdline for libparted-fs-resize.so
    applied 6523b6d1cb7a... gtk4: upgrade 4.10.3 -> 4.10.4
    applied a409dfdffcab... useradd-staticids.bbclass: improve error message
    applied 76e5fcb2d1a7... selftest reproducible.py: support different build targets
    applied 6f1867ac50e3... eudev: Upgrade 3.2.11 -> 3.2.12
    applied 860b98fc81b0... vulkan-validation-layers: cleanup recipe
    applied 4d99e7e58e04... gstreamer1.0-plugins-bad: use oneVPL instead of intel-mediasdk for msdk
    applied 3c73bbf9663d... devtool: Fix the wrong variable in srcuri_entry
    applied 424c66331336... linux-yocto/6.1: update to v6.1.33
    applied b6ab7d6bf33b... linux-yocto/6.1: fix intermittent x86 boot hangs
    applied 2734f66555b7... grub: submit determinism.patch upstream
    applied 87dccf731c3f... apr: upgrade 1.7.3 -> 1.7.4
    applied 6881acad8a5c... at-spi2-core: upgrade 2.48.0 -> 2.48.3
    applied b6f1d618ed19... btrfs-tools: upgrade 6.3 -> 6.3.1
    applied ee6305bdd097... attr: package /etc/xattr.conf with the library that consumes it
    applied c365c810c60a... glib-2.0: backport a patch to address ptest fails caused by coreutils 9.2+
    applied 76b7834c1ff8... diffoscope: upgrade 236 -> 242
    applied 7ef460054911... dnf: upgrade 4.14.0 -> 4.16.1
    applied 6b3bf71b60b9... ethtool: upgrade 6.2 -> 6.3
    applied 7a9f66121f63... gawk: upgrade 5.2.1 -> 5.2.2
    applied 3da65f786c0a... strace: upgrade 6.2 -> 6.3
    applied fcb9b65b259d... coreutils: upgrade 9.1 -> 9.3
    applied dc3263413352... coreutils: fix build when the host has fr_FR.
    applied 3217009b1443... gnupg: upgrade 2.4.0 -> 2.4.2
    applied fc4b924be849... gobject-introspection: upgrade 1.74.0 -> 1.76.1
    applied 18c1e5e976a1... kmscube: upgrade to latest revision
    applied 0f17022a75bd... libmodulemd: upgrade 2.14.0 -> 2.15.0
    applied 3499c35aab02... libuv: license file was split in two in the 1.45.0 version update
    applied bd40de6f7199... libx11: upgrade 1.8.4 -> 1.8.5
    applied 3e4f53be00f4... libxslt: upgrade 1.1.37 -> 1.1.38
    applied 75ee9049cba3... linux-firmware: upgrade 20230404 -> 20230515
    applied ec7f8bd6c9c8... ltp: upgrade 20230127 -> 20230516
    applied c6806570d966... mesa: upgrade 23.0.3 -> 23.1.1
    applied 4852226a5d50... meson: upgrade 1.1.0 -> 1.1.1
    applied 69f2b3c13fcd... mmc-utils: upgrade to latest revision
    applied 404bf4c7ca81... nettle: upgrade 3.8.1 -> 3.9
    applied 3dd8e2882929... nghttp2: upgrade 1.52.0 -> 1.53.0
    applied 89a86bc6426b... parted: upgrade 3.5 -> 3.6
    applied 6c1205e9218c... puzzles: upgrade to latest revision
    applied 4823710cbda2... python3: upgrade 3.11.2 -> 3.11.3
    applied 44e27450a8fd... python3-certifi: upgrade 2022.12.7 -> 2023.5.7
    applied 7155a6894fa1... python3-docutils: upgrade 0.19 -> 0.20.1
    applied 21d713e1e7b9... python3-flit-core: upgrade 3.8.0 -> 3.9.0
    applied c049db897f14... python3-importlib-metadata: upgrade 6.2.0 -> 6.6.0
    applied 73d8e82d7a9d... python3-pyasn1: upgrade 0.4.8 -> 0.5.0
    applied afeef7af5717... python3-pyopenssl: upgrade 23.1.1 -> 23.2.0
    applied 2b9ef6d640f1... python3-sphinx: remove BSD-3-Clause from LICENSE
    applied 98ed91039a1f... serf: upgrade 1.3.9 -> 1.3.10
    applied 8b8cf3e62040... shaderc: upgrade 2023.2 -> 2023.4
    applied d512b5765d16... squashfs-tools: upgrade 4.5.1 -> 4.6.1
    applied 55ceb0303576... vala: upgrade 0.56.6 -> 0.56.8
    applied 4aa75194e5e0... vulkan: upgrade 1.3.243.0 -> 1.3.250.0
    applied de721660c840... wget: upgrade 1.21.3 -> 1.21.4
    applied 15e32faa2191... wireless-regdb: upgrade 2023.02.13 -> 2023.05.03
    applied 3a06adf53e93... xf86-input-libinput: upgrade 1.2.1 -> 1.3.0
    applied 3ee077f991e7... xf86-input-mouse: upgrade 1.9.4 -> 1.9.5
    applied 609fc1571807... runqemu/qemu-helper: Drop tunctl
    applied 7b87f203c2e6... runqemu-if*: Rename confusing variable name
    applied c056757ca5ff... migration-guides: release-notes-4.3: update documentation notes
    applied ab06a2e244da... Add clarification for SRCREV
    applied f5be1af663b2... profile-manual: fix blktrace remote usage instructions
    applied 71b672b191af... variables.rst: document OEQA_REPRODUCIBLE_TEST_TARGET and OEQA_REPRODUCIBLE_TEST_SSTATE_TARGETS
    applied 7105586a68d0... reproducible-builds.rst: document OEQA_REPRODUCIBLE_TEST_TARGET and OEQA_REPRODUCIBLE_TEST_SSTATE_TARGETS
    applied 460fabb83475... oeqa/selftest/oescripts: Fix qemu-helper selftest
    applied 62c5556025bf... oeqa/logparser: Fix ptest No-section exception
    applied f6169ae9e0e4... strace: Disable failing test
    applied 23a32dba40f2... strace: Merge two similar patches
    applied ec7983a81272... zstd: upgrade 1.5.4 -> 1.5.5
    applied 5c6419bec687... gdb: upgrade 13.1 -> 13.2
    applied 88abdec715ed... selftest/reproducible: Allow chose the package manager
    applied f5b3ded656a4... rootfs-postcommands: change sysusers.d command
    applied ab0f42536f6a... systemd: replace the sysusers.d basic configuration
    applied 5eb501113730... base-passwd: add the wheel group
    applied 1a2aa5e536d4... oeqa/core/runner: add helper to know about expected failures
    applied cdac245fc288... oeqa/target/ssh: update options for SCP
    applied 58206ea8d94e... testimage: implement test artifacts retriever for failing tests
    applied 5967a90e8a00... testimage: Only note missing target directories, don't warn
    applied d01f87b4f8c2... base-passwd: fix patchreview warning
    applied 8502913bd3a6... ptest-runner: Pull in sync fix to improve log warnings
    applied 0ef2e5081b9c... kernel: Add kernel specific STRIP variable
    applied 0344ed776e71... libxml2: Do not use lld linker when building with tests on rv64
    applied 7cc253222e9c... llvm: Bump to 16.0.6
    applied 38af5819e1b4... go-helloworld: Upgrade to tip of trunk
    applied f1bae584ffb5... rpcsvc-proto: Upgrade to 1.4.4
    applied e964202dfc6b... bitbake.conf: add unzstd in HOSTTOOLS
    applied 17400624fa4f... libxcrypt: upgrade 4.4.33 -> 4.4.34
    applied 7a6620b5eb26... runqemu-gen-tapdevs: fix missing variable quote
    applied 51063c1e6ac2... scripts/runqemu-ifup: Fix extra parameter issue
    applied 18df7280ce92... scripts/runqemu-ifup: Fix 10 or more tap devices
    applied 3ba736c6cdf6... bitbake: bitbake-user-manual: explicit variables taking a colon separated list
    applied 6f8dd36ca0cc... bitbake: runqueue: Fix handling of virtual files in layername calculation
    applied 0b838bbc1ea6... sdk.py: error out when moving file fails
    applied 16f56a068028... sdk.py: fix moving dnf contents
    applied f669fe7ead9e... rpm: write macros under libdir
    applied 229813a628b7... cve-extra-exclusions: call out an Ubuntu-specific issue explicitly
    applied 37382c45eacb... cve-extra-exclusions: CVE-2023-3141 was backported in Linux 6.1.30
    applied 89e2844fdcee... erofs-utils: backport fixes for CVE-2023-33551 and CVE-2023-33552
    applied 6a7a4e40d5da... ghostscript: mostly rewrite recipe
    applied 36cb49a6b076... zstd: fix a reproducibility issue in 1.5.5
    applied 55b0208c333e... ptest-runner: Ensure data writes don't race
    applied 42921e63a496... bitbake.conf: Add layer-<layername> override support
    applied 6b26715fd7f6... insane: Improve patch-status layer filtering
    applied 8ed7880e1ec5... genericx86: Drop gma500-gfx-check
    applied d7a3e91bb493... bitbake: doc: Document FILE_LAYERNAME
    applied 8079e7a55ce3... glib-networking: use correct error code in ptest
    applied 3d8f1423fae3... bitbake: bitbake-user-manual: revert change about PREFERRED_PROVIDERS
    applied f9d22f263465... runqemu: Stop passing bindir to the runqemu-ifup call
    applied c9ac3632b27e... python3-bcrypt: Use BFD linker when building tests
    applied 9c6d3c68d030... zip: fix configure check by using _Static_assert
    applied a3d3db655f34... zip: remove unnecessary LARGE_FILE_SUPPORT CLFAGS
    applied d544cbf1d502... unzip: fix configure check for cross compilation
    applied a75cd36f392a... unzip: remove hardcoded LARGE_FILE_SUPPORT
    applied cc2c3b1b6207... rpm2cpio.sh: update to the last 4.x version
    applied 0a1c0f1396b0... u-boot-tools: Use PATH_MAX for path length
    applied db67eaf59435... python3-dbusmock: only recommend python3-pygobject
    applied 81b14b4d8554... sysfsutils: fetch a supported fork from github
    applied cec6d2af490d... sysfsutils: update 2.1.0 -> 2.1.1
    applied 4a4e568960dd... sysfsutils: don't install to base_libdir
    applied 74511c360a96... dbus: upgrade 1.14.6 -> 1.14.8
    applied f8bf2c551729... base: improve LICENSE_FLAGS_DETAILS output
    applied a1f722588437... logrotate: Do not create logrotate.status file
    applied 2d0913ff6f6c... runqemu-ifup: remove uid parameter
    applied 2401847d7333... runqemu-ifup: configurable tap names
    applied b97fe9d3e7dc... runqemu-ifup: fix tap index
    applied 292ca0207dfc... runqemu-ifup: remove only our taps
    applied 14dcde95ec24... runqemu-gen-tapdevs: remove staging dir parameter
    applied 6321e1fe7ab2... runqemu-gen-tapdevs: remove uid parameter
    applied 03566537a5a1... runqemu-gen-tapdevs: configurable tap names
    applied 9e1e717bf749... runqemu-gen-tapdevs: remove only our taps
    applied fe0ef2c6bb30... runqemu: configurable tap names
    applied 3cb6144e9492... linux-yocto/6.1: update to v6.1.34
    applied 0baac70b8ba5... linux-yocto/6.1: update to v6.1.35
    applied bd8d5e20f483... weston: Cleanup and fix x11 and xwayland dependencies
    applied 2aa3af4de3a0... bitbake: docs: bitbake-user-manual: bitbake-user-manual-hello: add links and highlights for variables
    applied 00016cecc434... ref-manual: variables.rst: explicit variables accepting colon separated lists
    applied 516d490aefd5... migration-guides: add notes on FILE_LAYERNAME
    applied 3115c9929812... migration-guides: add notes on systemd/usrmerge changes
    applied b0edf63ce0c9... docs: bsp-guide: bsp: fix typo
    applied ea88a4ca8298... docs: ref-manual: terms: fix typos in SPDX term
    applied dae1bc68986e... docs: fix unnecessary double white space
    applied ae8e1dc9909f... docs: ref-manual: terms: fix incorrect note directive
    applied 13b646c0e167... ref-manual: classes: devicetree: fix sentence saying the same thing twice
meta-security 180dac9aec -> 405cca4028:
    applied 440e1578198f... swtpm: fix parser error when using USERADDEXTENSION="useradd-staticids"
    applied c50757b2f17a... dmverity: Suppress the realpath errors
    applied 33b885c6eef6... buck-security: fix missing dependencies to perl modules
    applied f1b0c8f8d46a... scap-security-guide: update to 0.1.67
    applied c696be8b6a56... scap-security-guide: update to tip
    applied abf46b176414... scap-security-guide_git: drop oe version
    applied c00d101befbc... complicance/isafw: remove oeqa addpylib
    applied 54a808a4f92d... openscap-daemon: This is now obsolete
    applied 89b200a43ce5... oe-scap: Not maintained nor upstreamed
    applied bf47ba7c969a... openscap: Fix native build missing depends
    applied 994665045a79... openscap: Drop OE specific recipe
    applied 666a0c6ccfcf... lynis: move to main meta-security layer
    applied 4bfd29a330a7... openscap: move to main meta-security layer
    applied 51a07148625a... meta-security-compliance: remove layer
    applied 49de76c98020... openscap: add support for OpenEmbedded nodistro and Poky
    applied c4c7592dcbea... scap-security-guide: add OE support
    applied 6ae25c767337... packagegroup-core-security: add compliance pkg group
    applied 97ab23ef6401... kas: ci changes do to meta-security-compliance being removed
    applied ca8bd5faf855... meta-security-isafw: drop layer isafw project archived
    applied 4dc2b5202769... openscap: Update to tip to get OE/Poky support
    applied 2b052a616530... scap-security-guide: bump the number of test that pass
    applied ea97a23986d2... *.patch: add Upstream-Status to all patches
    applied 1459cf9cd5b3... clamav: drop unused patch
    applied 2eb05e11c0ca... isic: fine tune Upstream-Status
    applied b6ec838e8ff9... dm-verity: add descriptive strings for "wic list images"
    applied fc12521b0807... dm-verity: restructure the veritysetup arg parsing
    applied 39c69c8b5dd5... dm-verity: save veritysetup args beside runtime environment
    applied 4922b3053af9... dm-verity: add support for hash storage on separate partition
    applied 3b88f75323bd... dm-verity: add wks.in fragment with dynamic build hash data
    applied 521e7b040a60... dm-verity: hook separate hash into initramfs framework
    applied f1591a1579c4... dm-verity: add sample systemd separate hash example and doc
    applied 53c6324c5f2f... scap-security-guide: Add Poky
    applied d7769151998b... arpwatch: Fix typo in COMPATIBLE_HOST:libc-musl = "null"
    applied 965dee3282e1... scap-security-guide: add Upstream-Status
    applied 6cf7d71885d0... scap-security-guide: Does not build for musl
    applied 1fa205aedfc1... openscap: update to 1.3.8
    applied 515dd792baca... packagegroup-core-security: add os-release
    applied a070c55ac767... meta-tpm: *.patch: fix malformed Upstream-Status lines
    applied f5bc417f3234... dynamic-layers: *.patch: fix malformed and missing Upstream-Status lines
    applied df8a1eb47917... *.patch: fix malformed Upstream-Status and SOB lines
    applied 405cca40288d... .patch: remove probably unused patches
meta-raspberrypi 8e07f0d328 -> dff85b9a9f:
    applied 195c7d59bc64... *.patch: add Upstream-Status to all patches
    applied dff85b9a9f66... linux-raspberrypi-6.1: Update to 6.1.34 release

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
