### PR TITLE
subtree update: acda66195e -> 7103b545ea

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = b4d50a273dd3f6eb37c8fac8fab12d2bf70ffebe
+last_revision = 992c07f7c030caf0c52665cfbd2a30899bba7015
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 0e3f5e5201e3b9740b74df76a2a907983cc8b4e3
+last_revision = 491b7592f4408a1d7f32ddfb12b2c1613bcadfe1
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = e3f733caddd0e3f92c9efa968dbbac3e28a7eebc
+last_revision = 5e2f79a6faf91f73d7500bf38ac7795a263d9e36
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = 405cca40288d1c44f8cba12513f72dc578364313
+last_revision = b9bc938785ccbdf4337243a194fcad476fcde4c6
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = b398c7653ec6272178dd6403dfcadf475f677bf5
+last_revision = 71282bbc5331e7768c95d1dd6db94651de504734
 


### PR DESCRIPTION
meta-openembedded 0e3f5e5201 -> 491b7592f4:
    applied c5df8a7772e3... uutils-coreutils: upgrade 0.0.19 -> 0.0.20
    applied 665f9ae34e73... openh264: version bump 2.1.1 -> 2.3.1
    applied 31a9e70c845a... c-periphery: upgrade 2.4.1 -> 2.4.2
    applied 5ec3a875632f... ctags: upgrade 6.0.20230611.0 -> 6.0.20230716.0
    applied 26f2cb6360a8... gensio: upgrade 2.6.6 -> 2.6.7
    applied 95d1088e4fcb... gnome-commander: upgrade 1.16.0 -> 1.16.1
    applied cf2b77316ae5... hiredis: upgrade 1.1.0 -> 1.2.0
    applied fe28de1cda6d... iperf3: upgrade 3.13 -> 3.14
    applied 17a730a36d7d... iwd: upgrade 2.6 -> 2.7
    applied d8d615133377... libbytesize: upgrade 2.8 -> 2.9
    applied 4b90811e05da... libinih: upgrade 56 -> 57
    applied d35850759791... libnftnl: upgrade 1.2.5 -> 1.2.6
    applied e9c76a947d12... lvgl: upgrade 8.3.7 -> 8.3.8
    applied 1972581f18c6... bats: upgrade 1.9.0 -> 1.10.0
    applied ed72fea7422c... function2: upgrade 4.2.2 -> 4.2.3
    applied 42636744ceca... lmdb: upgrade 0.9.29 -> 0.9.31
    applied 68c1dd86c5f0... redis: upgrade 6.2.12 -> 6.2.13
    applied 43eb018d37be... ser2net: upgrade 4.3.12 -> 4.3.13
    applied 75d37f81e97d... python3-obd: upgrade 0.7.1 -> 0.7.2
    applied 5009fefd5d27... python3-path: upgrade 16.6.0 -> 16.7.1
    applied 99d6fd5c0f5b... nginx: upgrade 1.24.0 -> 1.25.1
    applied 98f9c81f1e7f... php: upgrade 8.2.7 -> 8.2.8
    applied b71dcebad5da... python3-charset-normalizer: upgrade 3.1.0 -> 3.2.0
    applied 50f3a9c47f0c... python3-click: upgrade 8.1.3 -> 8.1.5
    applied 8b9bf6051363... python3-dnspython: upgrade 2.3.0 -> 2.4.0
    applied 7256d140342f... python3-engineio: upgrade 4.4.1 -> 4.5.1
    applied 5db0c49710fa... python3-eth-utils: upgrade 2.1.1 -> 2.2.0
    applied d44f512eafca... python3-frozenlist: upgrade 1.3.3 -> 1.4.0
    applied 92b7f4661b92... python3-gevent: upgrade 22.10.2 -> 23.7.0
    applied 5a355243caa2... python3-google-api-python-client: upgrade 2.92.0 -> 2.93.0
    applied 7e3491b2d87b... python3-google-auth: upgrade 2.21.0 -> 2.22.0
    applied cd765ff58afa... python3-mock: upgrade 5.0.2 -> 5.1.0
    applied ee55f53a1225... python3-platformdirs: upgrade 3.8.0 -> 3.9.1
    applied 0b83dfbedb61... python3-protobuf: upgrade 4.23.3 -> 4.23.4
    applied fa272dbc68f4... python3-pymisp: upgrade 2.4.172 -> 2.4.173
    applied 0da49b20a446... python3-pymongo: upgrade 4.4.0 -> 4.4.1
    applied ec006ec36c46... python3-tox: upgrade 4.6.3 -> 4.6.4
    applied 45cee91314ef... python3-virtualenv: upgrade 20.23.1 -> 20.24.0
    applied 77c7af820cf2... python3-zeroconf: upgrade 0.70.0 -> 0.71.0
    applied 817ae6c4ad99... redis-plus-plus: upgrade 1.3.9 -> 1.3.10
    applied 47a49e9f58e7... redis: upgrade 7.0.11 -> 7.0.12
    applied d8f7858929d0... smemstat: upgrade 0.02.11 -> 0.02.12
    applied bb50c6e1f023... tesseract: upgrade 5.3.1 -> 5.3.2
    applied 9dbb5e1efc0b... weechat: upgrade 4.0.1 -> 4.0.2
    applied da2ce884848c... wireshark: upgrade 4.0.6 -> 4.0.7
    applied 27ed9360d93a... xterm: upgrade 383 -> 384
    applied 84c611db3472... python3-django: upgrade 4.2.2 -> 4.2.3
    applied 83e3242f0c01... python3-ipython: upgrade 8.12.0 -> 8.14.0
    applied 21ffd6f33fed... cherokee: add CVE_PRODUCT
    applied 51861886e03e... libtommath: add recipe for LibTomMath used by dropbear
    applied d449d72c4bf5... libtomcrypt: backport a fix for CVE-2019-17362
    applied 3a91bdb9cb6e... libtomcrypt: add PACKAGECONFIG for ltm enabled by default
    applied c575c5cb6968... yaml-cpp: Fix cmake export
    applied 40978c420007... dracut: Remove busybox from RRECOMMENDS
    applied a39ae61fab5b... vbxguestdrivers: upgrade 7.0.8 -> 7.0.10
    applied be2a2b575448... yasm: fix CVE-2023-31975
    applied 80ba83ad80c0... dlm: Do not use -fcf-protection=full on aarch64 platforms
    applied f2c2894f20d9... dlt-daemon: Add patch to fix build with googletest 1.13
    applied b968197cf377... python3-awesomeversion: upgrade 22.9.0 -> 23.5.0
    applied ea614493f37b... python3-binwalk: upgrade 2.3.3 -> 2.3.4
    applied 158596947532... python3-bitstring: upgrade 3.1.9 -> 4.0.2
    applied d14a71080782... python3-bitstring: add python3-io to RDEPENDS, alphabetize
    applied c2786d5a1359... python3-blinker: upgrade 1.5 -> 1.6.2
    applied ec003c58cd5e... python3-blinker: add python3-asyncio to RDEPENDS
    applied 7ab47960e7e9... python3-execnet: upgrade 1.9.0 -> 2.0.2
    applied d899bd8f64f8... python3-flask: upgrade 2.2.3 -> 2.3.2
    applied 89b9e328faca... python3-flask: add python3-blinker to RDEPENDS, alphabetize
    applied 2595f4cba76f... pipewire: update 0.3.73 -> 0.3.75
    applied a7278f9efa56... python3-greenstalk: upgrade 2.0.0 -> 2.0.2
    applied 4e0281797277... libcamera: update 0.0.5 -> 0.1.0
    applied 4b6b68721454... bitwise: Upgrade 0.43 -> 0.50
    applied 56d5b088e1db... python3-humanize: upgrade 4.4.0 -> 4.7.0
    applied 0eb4abcafd6a... python3-versioneer: add recipe
    applied 98f3ebfa0393... python3-parse: upgrade 1.19.0 -> 1.19.1
    applied b4dbeba98b26... python3-pandas: upgrade 1.5.3 -> 2.0.3
    applied b7653e2a1ba8... python3-pyperf: upgrade 2.5.0 -> 2.6.1
    applied 7e565b5c0c09... python3-rdflib: upgrade 6.2.0 -> 6.3.2
    applied ad4a71137e4a... mariadb: Upgrade to 10.11.4
    applied 73eda616eff7... openwsman: Link with -lm to get floor() definition
    applied 3baecf3983de... android-tools: fix QA warning about buildpaths
    applied 171df142f213... lastlog2: add new recipe
    applied 34609fd7bb2e... wtmpdb: add new recipe
    applied 6804adf7b022... python3-semver: upgrade 2.13.0 -> 3.0.1
    applied 2b488648deb7... python3-send2trash: upgrade 1.8.0 -> 1.8.2
    applied e3e0f46aa7b6... python3-sh: upgrade 1.14.3 -> 2.0.4
    applied ce2e087e9d88... python3-snagboot: upgrade 1.0 -> 1.1
    applied 8b8479ebf69e... python3-werkzeug: upgrade 2.2.3 -> 2.3.6
    applied 5942f5523b1a... python3-beautifulsoup4: upgrade 4.11.1 -> 4.12.2
    applied 0a8776ac1627... python3-fastjsonschema: upgrade 2.16.3 -> 2.18.0
    applied 109055a814b1... python3-jsonpatch: upgrade 1.32 -> 1.33
    applied fe48529f1c76... python3-m2crypto: upgrade 0.38.0 -> 0.39.0
    applied 3a63fbf62a72... python3-matplotlib: upgrade 3.6.3 -> 3.7.2
    applied c2d8018ba4e9... python3-pyaudio: upgrade 0.2.11 -> 0.2.13
    applied 7fc427838dde... python3-pybind11: upgrade 2.10.3 -> 2.11.1
    applied 74e70284acb2... python3-sqlparse: upgrade 0.4.3 -> 0.4.4
    applied 05cd18493a7f... rsyslog: update from 8.2302.0 to 8.2306.0
    applied 4c201ede9396... mstpd: Add initial recipe for mstpd
    applied 8af2f17a6fa8... cve_check: convert CVE_CHECK_IGNORE to CVE_STATUS
    applied 769d79278403... portaudio-v19: Update to latest tip of trunk
    applied 917c57797504... python3-pyaudio: Fix cross builds
    applied 65f1009ced94... samba: upgrade 4.18.4 -> 4.18.5
    applied fc0e3cb91ee3... meta-python: add python3-telnetlib3 package
    applied 297018672c5b... libnvme: add recipe
    applied 54d25dc20253... nvme-cli: upgrade 1.13 -> 2.5
    applied 213a15cb90ea... webkitgtk3: add recipe
    applied 616e93a55797... libnfnetlink: enable native build
    applied 0eedaa546125... libnetfilter-queue: enable native build
    applied dd18c5fea77c... daq: enable nfq module build
    applied 219c716dcf0e... geary: update 43.0 -> 44.0
    applied b85af2c8d0b3... libadwaita: move recipe to oe-core
    applied 0fa2840946d6... poco: Fix ptests
    applied ed334821c280... cve_check: fix conversion errors
    applied ecac50cbf52b... babeld: upgrade 1.12.2 -> 1.13.1
    applied d511b4e27611... ctags: upgrade 6.0.20230716.0 -> 6.0.20230730.0
    applied 52578306834e... gspell: upgrade 1.12.1 -> 1.12.2
    applied 74903b259634... libcompress-raw-bzip2-perl: upgrade 2.204 -> 2.206
    applied fc1f73a506f7... libcompress-raw-lzma-perl: upgrade 2.204 -> 2.206
    applied 2f235e0447de... libcompress-raw-zlib-perl: upgrade 2.204 -> 2.206
    applied 2b5ca7abffd3... libio-compress-lzma-perl: upgrade 2.204 -> 2.206
    applied 8b4911576ae5... libio-compress-perl: upgrade 2.204 -> 2.206
    applied 46a49b2a5904... libqb: upgrade 2.0.7 -> 2.0.8
    applied 33b0b0ca2fd0... logcheck: upgrade 1.4.2 -> 1.4.3
    applied 5779ec238a0f... mdio-tools,mdio-netlink: Upgrade recipes to 1.3.0
    applied 61dd618932cf... python3-dill: upgrade 0.3.6 -> 0.3.7
    applied d0805a5a16b3... python3-gunicorn: upgrade 20.1.0 -> 21.2.0
    applied d246afe8e028... python3-web3: upgrade 6.3.0 -> 6.7.0
    applied ba5d26d1d8b3... python3-aiohttp: upgrade 3.8.4 -> 3.8.5
    applied cd5bfd3755d0... python3-bitarray: upgrade 2.7.6 -> 2.8.0
    applied e9ab80bc51da... python3-click: upgrade 8.1.5 -> 8.1.6
    applied cce2d4416c0d... python3-cmake: upgrade 3.26.4 -> 3.27.0
    applied c08defc3f19a... python3-configargparse: upgrade 1.5.5 -> 1.7
    applied f1b443bc78a0... python3-cytoolz: upgrade 0.12.1 -> 0.12.2
    applied 2a5f5aeac97a... python3-dnspython: upgrade 2.4.0 -> 2.4.1
    applied 379fbedd8652... python3-elementpath: upgrade 4.1.4 -> 4.1.5
    applied ef673cde3013... python3-flask-socketio: upgrade 5.3.4 -> 5.3.5
    applied 6db16c60907b... python3-gnupg: upgrade 0.5.0 -> 0.5.1
    applied c53753e7157b... python3-google-api-python-client: upgrade 2.93.0 -> 2.95.0
    applied f67a317b5a4b... python3-grpcio: upgrade 1.56.0 -> 1.56.2
    applied 9ba895eb3c4a... python3-jedi: upgrade 0.18.2 -> 0.19.0
    applied 1b3c3ae6bba1... python3-marshmallow: upgrade 3.19.0 -> 3.20.1
    applied 9bc5c823b190... python3-portion: upgrade 2.4.0 -> 2.4.1
    applied 5a38445182d5... python3-pymodbus: upgrade 3.3.2 -> 3.4.1
    applied c686662c54c1... python3-robotframework: upgrade 6.1 -> 6.1.1
    applied a8eb40a15083... python3-tomlkit: upgrade 0.11.8 -> 0.12.1
    applied be496d5b0393... python3-typeguard: upgrade 4.0.0 -> 4.1.0
    applied ca4b22b3da77... python3-virtualenv: upgrade 20.24.0 -> 20.24.2
    applied b3052a5f9246... python3-zeroconf: upgrade 0.71.0 -> 0.71.4
    applied b9d943639049... rdma-core: upgrade 46.0 -> 47.0
    applied fc2f3e39e211... sip: upgrade 6.7.9 -> 6.7.10
    applied dff205f5a3b1... image_types_sparse: Fix syntax error
    applied 5760b66b3b10... iperf3: remove incorrect CVE_PRODUCT setting
    applied 1266c912afa0... gpsd: make sure gps-utils-python runtime-depends on python3-pyserial
    applied 1cedbb26f8e7... webkitgtk3: upgrade 2.40.2 -> 2.40.5
    applied 90c027da2922... libcamera: bump to latest master
    applied c85d1218e3c9... fuse3: update 3.14.1 -> 3.15.1
    applied 6b2b98e52de3... remove unused AUTHOR variable
    applied c1330b1f5335... remove unused AUTHOR variable
    applied be1b661b23ab... remove unused AUTHOR variable
    applied f14244a98cca... remove unused AUTHOR variable
    applied 706832c7a250... remove unused AUTHOR variable
    applied 847f144f29e9... remove unused AUTHOR variable
    applied 61d14138c22a... meta-python: Remove unused AUTHOR variable
    applied 16e1555f6cd4... rsyslog: Fix function inline errors in debug optimization
    applied a8d959a7dad7... radvd: Fix groupname gid change warning
    applied d572afcd08f3... cyrus-sasl: Fix groupname gid change warning
    applied 3b2f72f31a5e... pcmciautils: Pass LD=CC via Make cmdline
    applied 262cf7523021... pipewire: update 0.3.75 -> 0.3.77
    applied 38f525002cf6... pipewire: add support for liblc3
    applied 8a407d58a30a... ply: Pass LD via environment to configure
    applied 7a1365b22431... sip: upgrade 6.7.10 -> 6.7.11
    applied 976ccae201b8... nodejs: Upgrade to 18.17.0
    applied ca67bf7dfded... gnome-software: update 44.3 -> 44.4
    applied b160fcf8822b... lapack: Add ptest support
    applied 22d5614d2d0c... open-vm-tools: add CVE_PRODUCT
    applied 5adde6b9b8fd... python3-m2crypto: Remove __pycache__ files
    applied 6be235b5c3b7... libiio: update to version 0.25
    applied 8d353c049108... libmodule-build-tiny-perl: upgrade 0.045 -> 0.046
    applied 491b7592f440... grpc: fix CVE-2023-32732
meta-raspberrypi e3f733cadd -> 5e2f79a6fa:
    applied 8585b42bd61b... kas-poky-rpi.yml: renamed ABORT to HALT
    applied 05dceed00631... rpi-base.inc: add the disable-wifi overlay
    applied f78b4f159d6d... libcamera: update PACKAGECONFIG for libcamera-0.1.0
    applied be4867e494b4... rpidistro-vlc: fix error uint64_t does not name
    applied 3f12757165ba... rpi-base: Remove customizing SPLASH var
    applied 2ae93b0f9fdc... rpi-libcamera-apps: fix Illegal Instruction
    applied 48c3cc741313... rpi-libcamera-apps: add opencv build dependency
    applied 83a422668ca2... rpi-libcamera-apps: add drm support
    applied c0fca29ff33e... rpi-libcamera-apps: replace tensorflow config
    applied fbf6b355a35b... rpi-libcamera-apps: don't force COMPATIBLE_MACHINE
    applied d9ffd5c82816... rpi-libcamera-apps: rename to libcamera-apps
    applied 55b6e121f984... libcamera-apps: move recipe to dynamic-layers
    applied 9d9f98d2666b... libcamera-apps: bump to 3d9ac10
    applied 5f9423e4f912... libcamera-apps: switch from CMake to meson
    applied 5e2f79a6faf9... libcamera-apps: bump to latest main
meta-arm b4d50a273d -> 992c07f7c0:
    applied ddae9c4370... arm-bsp/trusted-firmware-a: corstone1000: psci: SMCCC_ARCH_FEATURES discovery through PSCI_FEATURES
    applied 79afe6a41e... arm-bsp/u-boot: corstone1000: upgrade to v2023.07
    applied 887e47b7c5... CI: add defaults for get-binary-toolchains
    applied cfcc8a4d13... CI: workaround 32bit timer warning in binary toolchain
    applied 9ea107c5fe... arm-bsp/corstone1000: update u-boot preferred version
    applied 308e5d7145... arm-bsp/trusted-firmware-a: Reserve OP-TEE memory from NWd on N1SDP
    applied 3cfe68f5cc... arm/recipes-devtools,doc: Update FVP version
    applied 92d4cabed3... arm-bsp/u-boot: corstone1000: increase the kernel size
    applied 938bbe9837... arm-toolchain/androidclang: remove
    applied 65504a799d... arm-toolchain/arm-binary-toolchain: install to a versioned directory
    applied 8d42065f41... arm-toolchain/gcc-arm-none-eabi-11.2: add new recipe
    applied d30ab1696e... arm/trusted-firmware-m: explicitly use Arm GCC 11.2
    applied 0e043288fd... arm-toolchain/gcc-arm-none-eabi: upgrade to 12.3.rel1
    applied 9fa8d0d0d0... arm-toolchain/gcc-aarch64-none-elf: upgrade to 12.3.rel1
    applied 299cb9e0b3... arm/edk2: move 202211 recipe to meta-arm-bsp
    applied ea797536da... arm-bsp: clean-up patch noise
    applied 07ec4baadf... arm/optee-test: update musl workaround patch
    applied 8c42263eb3... arm-bsp/tc1: remove trusted-firmware-m target
    applied c92ac97d79... arm/trusted-firmware-m: upgrade to v1.8.0
    applied 992c07f7c0... arm/recipes-kernel: Add preempt-rt support for generic-arm64
poky b398c7653e -> 71282bbc53:
    applied bbed3a143b... python3-dtschema: upgrade 2023.4 -> 2023.6.1
    applied 6684cfb613... python3-dtc: add from meta-virtualization
    applied a776b31811... python3-dtschema: add python3-dtc to RDEPENDS
    applied 795d8114d4... nfs-utils: upgrade 2.6.2 -> 2.6.3
    applied e4890e2276... file: return wrapper to fix builds when file is in buildtools-tarball
    applied 5a3e63f513... curl: Update from 8.1.2 to 8.2.0
    applied be48b99874... curl: Refine ptest perl RDEPENDS
    applied aa4c640d85... iproute2: upgrade 6.3.0 -> 6.4.0
    applied 915d601b1c... git: upgrade 2.39.3 -> 2.41.0
    applied ae1d378693... scripts/resulttool: add mention about new detected tests
    applied 71252e03e7... mdadm: add util-linux-blockdev ptest dependency
    applied 88ae1b73c0... kernel: make LOCALVERSION consistent between recipes
    applied db4946b66f... python3-urllib3: upgrade 2.0.3 -> 2.0.4
    applied e82334a907... python3-hypothesis: upgrade 6.81.2 -> 6.82.0
    applied 0276edeb71... python3-pyyaml: upgrade 6.0 -> 6.0.1
    applied 0cd6a81d6d... python_setuptools3_rust: inherit ...build_meta
    applied 7ed65df80f... cve-extra-exclusions: fix syntax error
    applied 5e7bf2a17d... createrepo-c: Fix 32 bit architecture segfaults with 64 bit time
    applied d6294101a8... glibc/check-test-wrapper: don't emit warnings from ssh
    applied 939e433c48... selftest/cases/glibc.py: increase the memory for testing
    applied 8bc29e1c87... oeqa/utils/nfs: allow requesting non-udp ports
    applied 02d38e9ce4... selftest/cases/glibc.py: switch to using NFS over TCP
    applied 3eff0eb5ea... build-appliance-image: Update to master head revision
    applied 9137761c0d... kmscube: bump SRCREV to get offscreen rendering to work
    applied 7807441927... linux-firmware: package firmare for Dragonboard 410c
    applied 8e4a74ed98... mesa: simplify overriding GALLIUMDRIVERS_LLVM
    applied 0da5484b2f... mesa: enable swrast Vulkan driver if LLVM drivers are enabled
    applied 9205ac1d53... file: fix the way path is written to environment-setup.d
    applied 5d66e8166f... nfs-utils: Fix host path contamination building locktest
    applied 12c9f826de... ltp: Use bfd linker when lld is distro linker default
    applied 67b51c40be... ffmpeg: Use bfd linker on i386 when lld is distro linker default
    applied afed7e8747... bitbake: fetch2: Set maxsplit to match expected variables
    applied aff6bc3249... oeqa/target/ssh: Ensure EAGAIN doesn't truncate output
    applied f35a017cf8... createrepo-c: Update patch status
    applied 94b9bc0b04... oeqa/runtime/ltp: Increase ltp test output timeout
    applied 8ace40e278... oeqa/ltp: Show warning for non-zero exit codes
    applied 10ab0949a1... ltp: Add kernel loopback module dependency
    applied 269479f6f4... target/ssh: Ensure exit code set for commands
    applied a10c01f9d1... base-passwd: Add the sgx group
    applied 36ed53a648... udev: eudev: Revert add group to sgx
    applied 5afd5091cc... ltp: Use bfd linker for KVM_LD as well when ld-is-lld
    applied d8a51fd628... bitbake: fetch2/gitsm: Document that we won't support propagating user parameter
    applied 231b7099e5... bitbake: contrib: vim: Fix up a few errors when reloading
    applied f35b5f5d20... autoconf: Upgrade to 2.72c
    applied baa99b3201... autoconf: Backport upstreamed patches
    applied 153499cb58... Revert "site: merged common-glibc from OE"
    applied de9508dbd3... x32-linux: Do not cache ac_cv_sys_file_offset_bits
    applied c2d0ac3f0d... oeqa/ssh: Further improve process exit handling
    applied 80cec38c0c... ptest-cargo.bbclass: Support of cargo workspaces
    applied 9b07dbc41f... rust: Fix BOOTSTRAP_CARGO failure during Rust Oe-selftest
    applied c496b1eaf4... oeqa/selftest/rust: Add failed test cases to exclude list for Rust Oe-selftest
    applied 4606d55e95... gcc: Upgrade to 13.2 release
    applied 5d65d26db3... oeqa/selftest/rust: Round test execution time to integer
    applied e0515a6a0d... meta: add missing summaries for image recipes
    applied e8c8337989... insane.bbclass: add do_recipe_qa task
    applied 2c7a4a8021... devtool: do not run recipe_qa task when extracting source
    applied ba961128e2... insane.bbclass: add a SUMMARY/HOMEPAGE check (oe-core recipes only)
    applied f6bd6b72f8... insane.bbclass: add a RECIPE_MAINTAINER check (oe-core recipes only)
    applied 43cf578a84... librsvg: fix upstream version check
    applied fc8241a606... acpica: tarball and homepage relocated to intel.com
    applied 7943dbae85... gnu-efi: upgrade 3.0.15 -> 3.0.17
    applied e06e72791c... gettext-minimal-native: obtain the needed files directly from gettext source tarball
    applied c9a55dcb25... kbd: upgrade 2.6.0 -> 2.6.1
    applied ecaf7e251d... systemd: upgrade 253.3 -> 253.7
    applied 0928f1d3c0... jquery: upgrade 3.6.3 -> 3.7.0
    applied dcb6abe86b... strace: upgrade 6.3 -> 6.4
    applied 2c92cddeb1... sudo: update 1.9.13p3 -> 1.9.14p2
    applied 254cc105ee... libadwaita: add recipe from meta-gnome
    applied 11cc1a1a88... epiphany: upgrade 43.1 -> 44.5
    applied a0748b0014... glibc-locale: use stricter matching for metapackages' runtime dependencies
    applied 3ae2716291... uninative-tarball: install the full set of gconv modules
    applied a2f1791f8d... buildtools-extended-tarball: install the full set of gconv modules
    applied 0b3ba1e2d9... procps: address failure with gettext 0.22
    applied fae96e779e... gcr3: remove recipe
    applied f07d09fe51... linux-firmware : Add firmware of RTL8822 serie
    applied a5a3130856... linux-firmware: split platform-specific Adreno shaders to separate packages
    applied 2f54f9bc01... maintainers.inc: Modify email address
    applied 5dd5f0f534... libarchive: ignore CVE-2023-30571
    applied 9e7036f3a7... cve-exclusion_6.1: correct typo in exclusion list name
    applied 4ddeb8ee8b... bluez5: correct CVE status of ignored CVEs
    applied 2046901b48... python3-sphinx: upgrade 7.0.1 -> 7.1.1
    applied 5760be9c24... python3-certifi: upgrade 2023.5.7 -> 2023.7.22
    applied 50167aeb06... python3-more-itertools: upgrade 9.1.0 -> 10.0.0
    applied d0e4e116d3... python3-wheel: upgrade 0.40.0 -> 0.41.0
    applied 1a93346e4f... gnu-efi: Fix build break on riscv64
    applied a193e855e0... ncurses: fix CVE-2023-29491
    applied 65bc175907... util-linux: upgrade 2.38.1 -> 2.39.1
    applied 5797574236... kernel-fitImage: add machine compatible to config section
    applied d505ab5ea5... patchelf: add 3 fixes to optimize and fix uninative
    applied 61bcec8a28... ffmpeg: Fix wrong code found with gas/2.41
    applied bed1597caf... poky/poky-tiny: Explicitly exclude `shadow`
    applied 69d68f6094... docs: sdk-manual: appendix-obtain: fix literal block content
    applied 7be9b1ff81... ref-manual: classes: kernel-fitimage: fix source of imagetype
    applied 7d4c1b2dd9... ref-manual: classes: kernel-fitimage: fix typos
    applied 9f51de2f9b... ref-manual: classes: kernel-fitimage: refine role of INITRAMFS_IMAGE_BUNDLE
    applied 25de21656a... ref-manual: releases.svg: updates
    applied daf11124fd... migration-guides: add release notes for 4.0.11
    applied 7d66f14574... ref-manual: LTS releases now supported for 4 years
    applied db7217335a... migration-guides: add release notes for 4.2.2
    applied e100e3e0b3... ref-manual: document CVE_STATUS and CVE_CHECK_STATUSMAP
    applied 6f361c81ba... ref-manual: document image-specific variant of INCOMPATIBLE_LICENSE
    applied fc8468024c... bitbake: tests.data: add test for inline python calling a def'd function
    applied a9d2012f50... bitbake: tests.codeparser: add test for exec of builtin from inline python
    applied 8b74f2ca55... bitbake: data_smart: check for python builtins directly for context lookup
    applied 042b70da3b... bitbake: tests.data: add test for builtin preferred over metadata value
    applied 7be82bf665... bitbake: data_smart: directly check for methodpool functions in context lookup
    applied 0402e69853... bitbake: bb.tests.data: don't require the func flag for context functions
    applied b3286e3024... alsa-utils: backport a fix to build with glibc-2.38
    applied 5fa764fff8... devtool/upgrade: raise an error if extracting source produces more than one directory
    applied 1666605fe5... scripts/lib/scriptutils.py: add recipe_qa artifacts to exclusion list in filter_src_subdirs()
    applied 93e8644287... systemd: update to v254
    applied 5fab97cc55... systemd: Point to target binary paths for loadkeys and setfont
    applied 266af294a2... systemd: Make 254 work on musl
    applied c9a9a95044... oeqa/selftest/binutils: Add elapsed time for binutils test report.
    applied 468b9fa034... oeqa/selftest/gcc: Add elapsed time for gcc test report.
    applied 2d2860206f... oeqa/selftest/glibc: Add elapsed time for glibc test report.
    applied 024bea3298... musl: Upgrade to tip of trunk
    applied 6de3817c62... scripts/resulttool: allow to replace test raw status with custom string
    applied 572d820da9... scripts/resulttool: define custom string for "not found" test results
    applied b5840b5636... binutils: Upgrade to 2.41 release
    applied b63831af2b... efivar: drop -fuse-ld=bfd
    applied 1f92db2d2c... bitbake: bitbake: fetch2/npmsw: Check if there are dependencies before trying to fetch them
    applied 058a44165c... bitbake: fetch2: Check if path is 'None' before calculating checksums
    applied 5477cad9b9... poky.conf: update SANITY_TESTED_DISTROS to match autobuilder
    applied b4180ef8e2... linux-yocto/6.4: fix CONFIG_LEDS_TRIGGER_GPIO kernel audit warning
    applied c0ef49e86c... linux-yocto/6.4: update to v6.4.6
    applied 48a40b35ca... linux-yocto/6.1: update to v6.1.41
    applied 68948f8dd4... linux-yocto/6.4: update to v6.4.7
    applied 0d0a43a5e6... linux-yocto-dev: bump to v6.5+
    applied 04851826d1... linux-yocto/6.4: update to v6.4.8
    applied cdf0cf72ef... linux-yocto/6.1: update to v6.1.43
    applied bc08748b3b... linux-yocto/6.4: update to v6.4.9
    applied 5ec6e05cbc... linux-yocto/6.4: fix qemuarm boot failure
    applied 96caf05219... systemd: set correct paths for kdb binaries
    applied 150feb7a64... systemd: depend on util-linux's swapon/off
    applied fbcce87a3a... package: always sort the conffiles
    applied f09444ffd1... base-files: bump PR because conf files are now sorted
    applied 5020abf342... curl: ensure all ptest failures are caught
    applied d4c14304c9... cargo.bbclass: Use --frozen flag for cargo operations
    applied 2dd04232e7... cargo_common.bbclass: Handle Cargo.lock modifications for git dependencies
    applied e9a09c8012... rust-hello-world: Drop recipe
    applied afcd4b9cbc... qemuboot/runqemu: Fix 6.2 and later kernel network device naming
    applied 84a7485025... bitbake: siggen: Improve runtaskdeps data to fix sstate debugging
    applied fa640ae676... sstatesig: Update to match bitbake changes to runtaskdeps
    applied 1bdcd76d29... oeqa/selftest/ssate: Add test for find_siginfo
    applied c558fddff7... systemd: fix efi stubs
    applied be13263987... systemd-boot: Ensure EFI_LD is also passed to compiler driver
    applied 8e6dc32e5e... systemd: add a packageconfig to support colored logs
    applied 6c03509349... wic: bootimg-efi: Stop hardcoding VMA offsets
    applied 04a4bac6d2... linux-yocto: add script to generate kernel CVE_STATUS entries
    applied 4adb195619... ghostscript: backport fix for CVE-2023-38559
    applied e6eb540236... ghostscript: ignore CVE-2023-38560
    applied 1f9434d51b... openssh: upgrade to 9.3p2
    applied 63e4205cda... librsvg: upgrade to 2.56.3
    applied b0152a3464... linux-yocto: extract generic kernel CVE_STATUS
    applied a26970fa3a... recipes: remove unused AUTHOR variable
    applied 75f22c4773... webkitgtk: upgrade 2.40.2 -> 2.40.5
    applied 89fdb041f7... epiphany: upgrade 44.5 -> 44.6
    applied e56b895866... python3: add additional timing-related test skips
    applied 515532b5c3... python3-chardet: upgrade 5.1.0 -> 5.2.0
    applied 9af6495ee4... python3-cryptography{-vectors}: upgrade -> 41.0.3
    applied afeb3baa8a... libgit2: upgrade to v1.7.0
    applied 418f160959... multilib.conf: explicitly make MULTILIB_VARIANTS vardeps on MULTILIBS
    applied 71370b5ecd... gcc-crosssdk: ignore MULTILIB_VARIANTS in signature computation
    applied 8cd7786bca... openssh: sync with upstream's default
    applied b06d0238c7... mdadm: save ptest logs
    skipped b40619a5b3... kernel: don't fail if Modules.symvers doesn't exist
    applied a85c8a5789... go: upgrade 1.20.6 -> 1.20.7
    applied 524a49f5de... bind: upgrade to v9.18.17
    applied c610b8dcd9... libexif: add ptest support
    applied 2abbc358ba... tcf-agent: Update to 1.8.0 release
    applied b4b218b069... linux-firmware: Fix mediatek mt7601u firmware path
    applied 795420850b... pm-utils: Do not require GNU grep at runtime
    applied 06335eab2f... linux-yocto-tiny/6.4: fix HID configuration warning
    applied a05abc02fa... kea: upgrade to v2.5.0
    applied b9813c6a4a... Revert "kea: upgrade to v2.5.0"
    applied b77e23c541... bitbake: server/process: fix sig handle
    applied 5df06735ac... yocto-uninative: Update hashes for uninative 4.1
    applied c4c58b13c2... selftest/reproducible: Update config to match ongoing changes
    applied 2850991c37... gnupg: Fix reproducibility failure
    applied 2c4cb6dba3... externalsrc: fix dependency chain issues
    applied 67a8dcabda... selftest: Ensure usrmerge is enabled with systemd
    applied d4933d1006... conf/init-mamager-systemd: Add usrmerge to DISTRO_FEATURES
    applied c4e6a67a8a... systemd: add usrmerge to REQUIRED_DISTRO_FEATURES
    applied d7ce7d6799... bitbake.conf: Drop PE and PR from WORKDIR and STAMP
    applied 71282bbc53... qemuboot: Update hardcoded path to match new layout
meta-security 405cca4028 -> b9bc938785:
    applied 7840dd1b53... bastille: bastille/config should not be world writeable.
    applied 3d2533f329... ossec-hids: Fix usermod
    applied 0e62092564... python3-flask-script: add package
    applied 4678955b35... python3-segno: add new package
    applied 4306007fee... python3-privacyidea: fixup REDPENDS
    applied cfe7335568... qemu: move qemu setting to image and out of layer.conf
    applied e4318a3c5a... packagegroup-core-security: only include firejail x86-64 and arch64
    applied 1dd076d3a7... firejail: only allow x86-64 and arm64 to build
    applied c56573730f... python3-tpm2-pytss: add python tss2 support
    applied c3d96a66fe... packagegroup: add python3-tpm2-pytss
    applied 4c787f3258... clamav: update SRC_URI
    applied 64b8f9b68e... scap-security-guide: refactor patches
    applied be8b6b20d6... packagegroup-security-tpm2: add more pkgs
    applied ef184ce03a... openscap: fix buildpaths issue
    applied 1ca654ef4f... scap-security-guide: enable ptest
    applied 108ab6d75e... python3-yamlpath: Add new pkg
    applied b713a8e661... python3-json2html: add new pkg
    applied 686c7c0b8a... python3-json2html: add new pkg
    applied d47553303c... meta-integrity: drop ima.cfg in favor of new k-cache
    applied a94674c5bc... dm-verity-image-initramfs: Allow compressed image types
    applied 21bb5627e0... glome: update to tip
    applied 782251aa8f... sssd: 2.7.4 -> 2.9.1
    applied 02f285b276... sshguard: Update to 2.4.3
    applied b727a4c94d... linux-yocto-rt: Add the bbappend for rt kernel
    applied 39d373acd1... meta-tpm linux-yocto-rt: Add the bbappend for rt kernel
    applied b9bc938785... layer: add QA_WARNINGS to all layers

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
