### PR TITLE
subtree update: a4efaf7ad3 -> bc8282bad5

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,19 +2,19 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 1dff3300fb923f08dd0ac3af19e37e9c0abb4aea
+last_revision = 0b61cc659a992e59c157fbf0be6d50919c464613
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 991e6852a53e0fcd40af8f0386d7f46bb318015e
+last_revision = 5ad7203f68987461baaf2699378d0cf36c11d6c2
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 8231f97534812cb0c6ab8d500eff44d3880fdac5
+last_revision = fde68b24f08b0eac4ad4bfd3c461dc17fe3a263c
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -26,5 +26,5 @@ last_revision = 070a1e82cc59424d230a23c0b2a104b01fbaa2ad
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 2696bf8cf35ca51b5147f6d462a1a9acea63097a
+last_revision = 028b6f62263c08097494f72ba43e2febe59b74e8
 


### PR DESCRIPTION
meta-arm 1dff3300fb -> 0b61cc659a:
    applied 0b61cc659a9... meta-arm/selftest: add test that PAC/BTI instructions are used
meta-openembedded 991e6852a5 -> 5ad7203f68:
    applied 45ce7272951... libcacard: fix version string in libcacard.pc
    applied 304fd6a06e1... cups-filters: fix Makefile race condition
    applied 092502feedc... system-config-printer: Add packageconfig for polkit
    applied 0d6871a86be... redis: Inherit pkgconfig
    applied 20c083b15b6... pipewire: upgrade 0.3.85 > 1.0.0
    applied eff650e3f6d... nlohmann-json: Fix SRCREV_FORMAT and do not package git metadata into ptests
    applied 9f0b5053410... apache2: v2.4.57 to v2.4.58 to fix CVE-2023-43622
    applied ec7ab6b4353... squashfs-tools-ng: upgrade 1.1.4 -> 1.2.0
    applied dc67e26b2f9... ctags: upgrade 6.0.20231119.0 -> 6.0.20231126.0
    applied c6dc0174389... freeradius: make sub packages to runtime depends on freeradius
    applied 0a1199bebbb... dnfdragora: upgrade 2.1.4 -> 2.1.5
    applied b57a328c363... gensio: upgrade 2.7.7 -> 2.8.0
    applied 94f462ce829... frr: upgrade 9.0.1 -> 9.1
    applied 5c9927db548... capnproto: upgrade 1.0.1 -> 1.0.1.1
    applied 9d050771dfc... libbpf: upgrade 1.2.2 -> 1.3.0
    applied e4fa64c5961... paho-mqtt-cpp: upgrade 1.2.0 -> 1.3.1
    applied 8fd762ae34d... tomoyo-tools: upgrade 2.5.0 -> 2.6.1
    applied a75bbe38622... python3-aiohttp: upgrade 3.9.0 -> 3.9.1
    applied 94302d54c76... python3-bitstring: upgrade 4.1.2 -> 4.1.3
    applied 69ddfb9c36b... python3-dbus-fast: upgrade 2.14.0 -> 2.15.0
    applied 4ce28b4bc20... python3-humanize: upgrade 4.8.0 -> 4.9.0
    applied ef82d420dda... python3-ipython: upgrade 8.17.2 -> 8.18.0
    applied d72f6cf2f20... python3-mypy: upgrade 1.7.0 -> 1.7.1
    applied d0fdcca9b21... python3-pdm: upgrade 2.10.3 -> 2.10.4
    applied 42907a1786e... python3-pexpect: upgrade 4.8.0 -> 4.9.0
    applied d9a5eaf0f18... python3-pychromecast: upgrade 13.0.7 -> 13.0.8
    applied 0260e1498e4... python3-pydantic: upgrade 2.5.1 -> 2.5.2
    applied 178cae38187... python3-pymisp: upgrade 2.4.178 -> 2.4.179
    applied 992f254d563... python3-pytest-xdist: upgrade 3.4.0 -> 3.5.0
    applied aff494f4c07... python3-sentry-sdk: upgrade 1.35.0 -> 1.37.1
    applied a982f406c07... python3-types-setuptools: upgrade 68.2.0.1 -> 68.2.0.2
    applied 49eabb2afd6... python3-virtualenv: upgrade 20.24.6 -> 20.24.7
    applied 426af6cf6a8... redis: upgrade 7.2.2 -> 7.2.3
    applied 21cdf209956... ser2net: upgrade 4.5.1 -> 4.6.0
    applied 5a77dd140c6... thingsboard-gateway: upgrade 3.4.2 -> 3.4.3.1
    applied 69d80c3a192... tmate: Fix finding msgpack 6+
    applied e12d38e91ef... linuxptp: Update downstream patches
    applied fe0d5e65cd8... msgpack-c: upgrade 4.0.0 -> 6.0.0
    applied 3991d85383b... msgpack-cpp: upgrade 4.1.1 -> 6.1.0
    applied a4e9bec26db... fio: revert "fio: upgrade 3.32 -> 2022"
    applied 7f0c536b357... brotli: upgrade 1.0.9 -> 1.1.0
    applied f687541cd4c... icewm: upgrade 2.9.9 -> 3.4.4
    applied b36f67da93a... iotop: upgrade 1.21 -> 1.25
    applied 41f16dc063f... ptest-packagelists-meta-oe.inc: Move poco to slow tests
    applied e1eafe6d9b8... sdbus-c++-libsystemd: Upgrade to 254
    applied cdac7e90f0d... sdbus-c++-tools: Upgrade to 1.4.0
    applied f4972749457... squid: update from v5.7 to v6.5
    applied a5f13e6231d... squid: add nm dispatcher reload hook
    applied fa560acfdb3... squid: add auth packageconfig
    applied 10ac056fc08... squid: move configs to sub package
    applied a7275d4c1e9... squid: add url-rewrite-helpers packageconfig
    applied 501e5aa4b56... squid: add systemd service
    applied d5f16f18c3b... tbb: upgrade 2021.9.0 -> 2021.11.0
    applied 6fbe5001895... tbb: enable NUMA/Hybrid CPU support
    applied eeb57e1e8a2... libcacard: set meson version based on PV
    applied 94b6de1cbc3... spice: Set meson version based on PV
    applied 9728eb6b4e9... spice-gtk: Set meson version based on PV
    applied 2151bcdada2... liblognorm: upgrade 1.0.1 -> 2.0.6
    applied 5bd7f4c60b1... python3-validators: add new recipe
    applied 9b8bb00bd6e... libmodbus: upgrade 3.1.7 -> 3.1.10
    applied dae158819f8... monocypher: add crypto library recipe
    applied d412f690df7... gstd: Fix systemd user unit packaging
    applied 5d7cb6ec416... basu: Update to latest master
    applied b1d55efe056... sdbus-c++: Install ptests into PTEST_PATH
    applied d3bd2ddf192... libpwquality: upgrade 1.4.4 -> 1.4.5
    applied d90c134f448... glog: Disable 64bit atomics on armv{5,6}
    applied f5279055e59... libdecor: update 0.2.0 -> 0.2.1
    applied 8dba0c9bad9... liblognorm:Add asprintf to autoconf function check macro
    applied 5857cd0f42e... xdg-desktop-portal-gnome: upgrade 45.0 -> 45.1
    applied 22051d98b39... libnma: remove conflict xml file
    applied 8140da48c3c... gnome-console,gnome-terminal: Depend on vte from core layer
    applied 21cecf46a52... Revert "gnome-terminal: Remove recommendation on vte-prompt"
    applied 284590b4a42... vte9: Drop recipe
    applied 1497396bfac... libspiro: upgrade 20200505 -> 20221101
    applied 3c4c881e134... gtkwave: upgrade 3.3.111 -> 3.3.117
    applied 5ad7203f689... basu: Update the SRCREV to get lld fix
poky 2696bf8cf3 -> 028b6f6226:
    applied 7943caf90cb... bitbake: ui/ncurses: Add missing function call to avoid traceback
    applied 27f7ef2e44b... bitbake: cooker: Avoid eventlog variable listing lockups
    applied 1a07f7ab5ed... python3-sphinxcontrib-applehelp: 1.0.4 -> 1.0.7
    applied ba982b8ecf6... python3-sphinxcontrib-devhelp: 1.0.2 -> 1.0.5
    applied 4460123d049... python3-sphinxcontrib-htmlhelp: 2.0.1 -> 2.0.4
    applied 54a972040d4... python3-sphinxcontrib-qthelp: 1.0.3 -> 1.0.6
    applied e59dcbc1149... python3-sphinxcontrib-serializinghtml: 1.1.5 -> 1.1.9
    applied 0769ff28dbd... systemd-compat-units.bb: fix postinstall script
    applied dfedec4b2d2... wic: add test for partition hidden attributes
    applied 5d12c0a3dc8... wic: rawcopy: add support for zstd decompression
    applied 3e50e459178... rust: Split rustdoc into a separate package
    applied 07462992787... cmake-qemu.bbclass: support qemu for cmake
    applied 053af0fc1e9... bind: upgrade 9.18.19 -> 9.18.20
    applied 81827e8c674... diffoscope: upgrade 251 -> 252
    applied 07726cef771... ell: upgrade 0.59 -> 0.60
    applied 124422a57fb... git: upgrade 2.42.1 -> 2.43.0
    applied 9a8af2a800a... gnutls: upgrade 3.8.1 -> 3.8.2
    applied 4ea5f4ec9fd... libdrm: upgrade 2.4.117 -> 2.4.118
    applied 318978b539f... libgcrypt: upgrade 1.10.2 -> 1.10.3
    applied 858d1947f61... libksba: upgrade 1.6.4 -> 1.6.5
    applied 0bf9a1ba78b... libxslt: upgrade 1.1.38 -> 1.1.39
    applied 5b5517bc164... log4cplus: upgrade 2.1.0 -> 2.1.1
    applied 6169a630b84... python3-certifi: upgrade 2023.7.22 -> 2023.11.17
    applied 376c20b6861... python3-setuptools: upgrade 68.2.2 -> 69.0.2
    applied 7ea7bb735e1... python3-wcwidth: upgrade 0.2.9 -> 0.2.11
    applied f0208261561... python3-hypothesis: upgrade 6.89.0 -> 6.90.0
    applied edadad94b00... python3-pyasn1: upgrade 0.5.0 -> 0.5.1
    applied 1b0b4055dd6... python3-scons: upgrade 4.5.2 -> 4.6.0
    applied 6a52222c11b... python3-urllib3: upgrade 2.0.7 -> 2.1.0
    applied 3a9d725fb32... shared-mime-info: Fix build with clang-17+
    applied 9f57bfb74e2... libsoup-2.4: Fix build with clang-17 and libxml2-2.12
    applied fad57568924... busybox: Enable utmp support on musl systems
    applied fcff0674078... devtool: fix update-recipe dry-run mode
    applied c7ed37b5ffd... lib/oe/recipeutils.py: remove trailing white-spaces
    applied eea4746ef5a... python3-ptest: skip test_storlines
    applied 71b30389791... vim: upgrade 9.0.2068 -> 9.0.2130
    applied 7b1b3f2abe7... python3-pyproject-hooks: fix upstream version check
    applied c018b6e6084... cmake: upgrade 3.27.5 -> 3.27.7
    applied f8199bc9086... desktop-file-utils: upgrade 0.26 -> 0.27
    applied 4ab32e3f767... erofs-utils: upgrade 1.6 -> 1.7.1
    applied 4fbbc2609d8... webkitgtk: update 2.40.5 -> 2.42.2
    applied d2eade15b73... epiphany: upgrade 44.6 -> 45.1
    applied 7e545ebf2f1... virglrenderer: upgrade 0.10.4 -> 1.0.0
    applied fb42c6a231c... libxkbcommon: upgrade 1.5.0 -> 1.6.0
    applied 7b06237008e... mpg123: upgrade 1.31.3 -> 1.32.3
    applied df9d98a19c5... icu: upgrade 73-2 -> 74-1
    applied c4f87eda9e8... p11-kit: upgrade 0.25.0 -> 0.25.2
    applied 1b6368ed099... glib-2.0: install gio-querymodules into bindir as well as libexecdir for native
    applied 90818b1c5de... meson: update 1.2.2 -> 1.3.0
    applied 8b88f0431c2... repo: update 2.37 -> 2.39
    applied 5c1d35356ae... rt-tests: update 2.5 -> 2.6
    applied a9db3010b91... glibc: stable 2.38 branch updates
    applied a4ddc1415b3... binutils: stable 2.41 branch updates
    applied d069eb3af4f... core-image-minimal-initramfs: don't install a kernel into the initramfs
    applied 1ae4cc7a115... devtool: finish/update-recipe: restrict mode srcrev to recipes fetched from SCM
    applied 17427db1364... devtool: tag all submodules
    applied 89f16624842... devtool: add support for git submodules
    applied 49f549a1428... oeqa/selftest/devtool: add test for git submodules
    applied 017b18f7d04... bluez5: fix connection for ps5/dualshock controllers
    applied a1a87182d13... systemd: fixed typo
    applied 3f96cab3c4c... lttng-modules: fix build for v6.7+
    applied 505dad0d671... rust: Delete python2 configparser code path
    applied 80783106740... rust: Drop TARGET_VENDOR export
    applied 5785754244b... dev-manual: layers: update link to YP Compatible form
    applied 9773b0c64c9... contributor-guide: add License-Update tag
    applied dbcc4df413c... contributor-guide: fix command option
    applied 275240132e8... migration-guides: add release notes for 4.3.1
    applied e2c364a6426... migration-guides: release 3.5 is actually 4.0
    applied ea96025188c... libpam: split /etc/environment into pam-plugin-env package
    applied 4371f927bc5... cups: Add root,sys,wheel to system groups
    applied fdbf7792457... bitbake.conf: Add gsutil as hosttool for gcp fetcher.
    applied d6d94eed1e1... cve-update-nvd2-native: remove unused variable CVE_SOCKET_TIMEOUT
    applied 30e986ea3ff... cve-update-nvd2-native: make number of fetch attemtps configurable
    applied abea4369a23... gnu-config: Update to latest revision
    applied bd00c3de144... gettext: Upgrade 0.22 -> 0.22.3
    applied 6481e8b209b... json-c: fix icecc compilation
    applied 629403e5ecb... ethtool: upgrade 6.5 -> 6.6
    applied c795b63a8ec... gi-docgen: upgrade 2023.1 -> 2023.3
    applied 61638b4d855... init-system-helpers: upgrade 1.65.2 -> 1.66
    applied 3e8743831bd... libsolv: upgrade 0.7.26 -> 0.7.27
    applied 60fe92fa356... python3-idna: upgrade 3.4 -> 3.6
    applied befba496294... ofono: upgrade 2.1 -> 2.2
    applied df8f9ed7cad... python3-sphinx-rtd-theme: upgrade 1.3.0 -> 2.0.0
    applied c3d97f203cf... python3-trove-classifiers: upgrade 2023.11.14 -> 2023.11.22
    applied ea908dff17a... python3-wheel: upgrade 0.41.3 -> 0.42.0
    applied 2364a81460b... resolvconf: upgrade 1.91 -> 1.92
    applied 291bc9e96a1... cve-check: Modify judgment processing using "=" in version comparison
    applied 076862d68e2... python3-cryptography-vectors: add RECIPE_NO_UPDATE_REASON
    applied a5ee86fd998... python3-cryptography{-vectors}: 41.0.5 -> 41.0.7
    applied e0a7cccb95e... virglrenderer: Fix build with clang
    applied 9e7de168847... llvm: Upgrade to 17.0.6
    applied c55cb443d02... rust-common.bbclass: Define rust arch for x32 platforms
    applied 715898cb9a2... bitbake: toaster/tests: Update methods wait_until_~ to skip using time.sleep
    applied 2ee91ebd9cf... bitbake: toaster/tests: Override table edit columns TestCase from image recipe page
    applied 9f78fee2733... bitbake: toaster/tests: Test software recipe page
    applied 9de0b70cc30... bitbake: toaster/tests: Added Machine page TestCase
    applied 00fb8ffca38... bitbake: toaster/tests: Added Layers page TestCase
    applied 5cd899da394... bitbake: toaster/tests: Added distro page TestCase
    applied 200541ec562... bitbake: toaster/tests: Bug-fix on tests/functional/test_project_page
    applied eb2af42e0a8... bitbake: toaster/tests: Test single layer page
    applied 5b18ff6d6be... bitbake: toaster/tests: Test single recipe page
    applied 6b6374c3360... bitbake: bitbake-hashclient: Add commands to get hashes
    applied 64725a9c324... bitbake: bitbake: tests: Fix duplicate test_underscore_override test
    applied 1f8a639a67a... bitbake: fetch2: Ensure GCP fetcher checks if file exists before download.
    applied 849bd6e3003... autoconf: upgrade to 2.72d
    applied 87fdb2fb6f4... systemd-boot: Fix build issues on armv7a-linux
    applied 5369e2f5c5d... openssl: upgrade to 3.2.0
    applied 2a888143420... iptables: upgrade 1.8.9 -> 1.8.10
    applied 5c1070e2586... patchtest: shorten patch signed-off-by test output
    applied 8bea1bd57c0... rust-llvm: Allow overriding LLVM target archs
    applied d5813d502a5... eudev: Upgrade 3.2.12 -> 3.2.14
    applied 377078dd943... shadow: Fix for CVE-2023-4641
    applied b0e7eda54f4... bash: changes to SIGINT handler while waiting for a child
    applied 0e6be258a50... documentation.conf: fix do_menuconfig description
    applied e7a87eb762f... cmake: Unset CMAKE_CXX_IMPLICIT_INCLUDE_DIRECTORIES
    applied 0a39f1aa091... wic: bootimg-efi: Make kernel image installation configurable
    applied 95d8a12b315... oeqa/selftest/wic: Add tests for kernel image installation
    applied de401f80ae4... rust: Drop targets and hosts override magic
    applied edc72a4bd1c... shared-mime-info-native: handle old GCC for AlmaLinux8
    applied 66d35dedcdd... vte: upgrade 0.72.2 -> 0.74.0
    applied b6af0e3be79... vte: Upgrade to 0.74.1
    applied f89d9240b12... vte: Separate out gtk4 pieces of vte into individual packages
    applied 70ad9b9b309... bitbake: hashserv: sqlite: Ensure sync propagates to database connections
    applied 028b6f62263... Revert "cve-check: Modify judgment processing using "=" in version comparison"
meta-raspberrypi 8231f97534 -> fde68b24f0:
    applied fde68b24f08... docs: fix syntax for overriding fs type for initramfs image

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
