### PR TITLE
nanbield: set meta-raspberrypi to use nanbield branch

### DIFF
--- a/nanbield.conf
+++ b/nanbield.conf
@@ -13,7 +13,7 @@ last_revision = 1750c66ae8e4268c472c0b2b94748a59d6ef866d
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
-branch = master
+branch = nanbield 
 last_revision = 8231f97534812cb0c6ab8d500eff44d3880fdac5
 
 [meta-security]


### PR DESCRIPTION
Upstream has created the branch now.  Update the config.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
