### PR TITLE
subtree update: 885c5d0a0a -> 432d4db320

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 0b61cc659a992e59c157fbf0be6d50919c464613
+last_revision = 4d22f982bce8dff6f8c4d11845c47a4d39f961c6
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 5ad7203f68987461baaf2699378d0cf36c11d6c2
+last_revision = 7d8115d5507bac6c018fbff8a7aa9bc513c2bc46
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = fde68b24f08b0eac4ad4bfd3c461dc17fe3a263c
+last_revision = 4c033eb07442959ed76d769fd2b4649612327155
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = 070a1e82cc59424d230a23c0b2a104b01fbaa2ad
+last_revision = b2e1511338705f90f34f19f938650c185200c067
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 028b6f62263c08097494f72ba43e2febe59b74e8
+last_revision = 4675bbb757a4755e80914afb6840a640f292fc08
 


### PR DESCRIPTION
meta-raspberrypi fde68b24f0 -> 4c033eb074:
    applied 4c033eb0744... rpi-cmdline, rpi-u-boot-src: Support USB boot
meta-arm 0b61cc659a -> 4d22f982bc:
    applied 310cd898ba0... CI: switch back to master
    applied f0d7b9db317... arm/trusted-firmware-a: move patch file to bbappend
    applied 3835b78f03a... arm/trusted-firmware-a: update to 2.10
    applied 560075f050c... arm/hafnium: update to v2.10
    applied 32dfb759cdf... arm-bsp/documentation: corstone1000: fix the steps in the user guide and instructions
    applied 553cadc720f... corstone1000:arm-bsp/optee: Update optee to v4.0
    applied e6e7ac4d99f... CI: rename meta-secure-core directory
    applied 65460e53103... arm/edk2: update to 202311
    applied b59c60c03a3... arm-systemready: Add parted dependency and inherit testimage
    applied aec92016d27... ci: Add Arm SystemReady firmware and IR ACS builds
    applied 4d22f982bce... corstone1000:arm-bsp/tftf: Fix tftf tests on mps3
poky 028b6f6226 -> 4675bbb757:
    applied 0f4fe4f7630b... bitbake: runqueue: Improve inter setscene task dependency handling
    applied 2d1f6c055d9f... bitbake: toaster/test: bug-fix on tests/browser/test_all_builds_page
    applied 8efe835e3bba... bitbake: toaster/test: from test_no_builds_message.py wait for the empty state div to appear
    applied 829953631ba7... bitbake: toaster/test: delay driver action until elements to appear
    applied 029e82d41837... bitbake: bb/toaster: Fix assertEquals deprecation warnings
    applied c2484f3dec96... bitbake: toaster: Fix assertRegexpMatches deprecation warnings
    applied 786ba56074ca... bitbake: toastermain/settings: Avoid python filehandle closure warnings
    applied 73ef8d57e0b9... bitbake: toastergui: Fix regex markup issues
    applied 28f57b8ceea1... bitbake: bitbake: Move to version 2.6.1 to mark runqueue changes
    applied 637fdcc2b13d... bitbake: toaster: fix pytest build test execution and test discovery
    applied 3ee5c86da377... bitbake: toaster-eventreplay: Remove ordering assumptions
    applied 344e10a21b88... recipetool: create_buildsys_python.py: initialize metadata
    applied 86b9510bd3b7... recipetool: create: add trailing newlines
    applied 6c06fb0a4395... recipetool: create: add new optional process_url callback for plugins
    applied 85a2a6f68af3... recipetool: create_buildsys_python: add pypi support
    applied 9f4df13f643b... oeqa/selftest/recipetool: remove spaces on empty lines
    applied a02279663f91... oeqa/selftest/recipetool/devtool: add test for pypi class
    applied 37076ad1e1f8... python3-bcrypt: upgrade 4.0.1 -> 4.1.1
    applied ef7ba05995ed... python3-pygments: upgrade 2.16.1 -> 2.17.2
    applied 29b2bda7867e... wic: extend empty plugin with options to write zeros to partiton
    applied 2da0213eeef3... selftest: wic: add test for zerorize option of empty plugin
    applied 280267d37907... gtk4: upgrade 4.12.3 -> 4.12.4
    applied b4db98289bb2... json-glib: upgrade 1.6.6 -> 1.8.0
    applied 58c6ae081808... psplash: upgrade to latest revision
    applied 9feb8f9284d3... ell: upgrade 0.60 -> 0.61
    applied a9168feacb6d... avahi: update URL for new project location
    applied 66734b787a1e... gettext: Upgrade 0.22.3 -> 0.22.4
    applied 41ffa169123c... oeqa/runtime/parselogs: load ignores from disk
    applied 9406c0d28f73... oeqa/runtime/parselogs: migrate ignores
    applied 2a20575e52ee... meta-yocto-bsp/oeqa/parselogs: add BSP-specific ignores
    applied 720ad02ae6b9... systemtap: upgrade 4.9 -> 5.0
    applied 5e8b43f8ca95... systemtap: do not install uprobes and uprobes sources
    applied 463d56b9f075... systemtap-uprobes: removed as obsolete
    applied 2c59f5ad01aa... lib/oe/patch: handle creating patches for CRLF sources
    applied de5ab8e8634b... recipetool: appendsrcfile(s): add dry-run mode
    applied eb0b664c8c0c... recipeutils: bbappend_recipe: fix undefined variable
    applied b45cab4e1c16... recipeutils: bbappend_recipe: fix docstring
    applied 11d4d437d52a... recipeutils: bbappend_recipe: add a way to specify the name of the file to add
    applied 165626f7b97d... recipeutils: bbappend_recipe: remove old srcuri entry if parameters are different
    applied 29dc0d73154f... recipetool: appendsrcfile(s): use params instead of extraline
    applied 0ae9cf237394... recipeutils: bbappend_recipe: allow to patch the recipe itself
    applied bc9291c5fd25... recipetool: appendsrcfile(s): add a mode to update the recipe itself
    applied 7ff486d556e6... oeqa/selftest/recipetool: appendsrfile: add test for machine
    applied ec340f14dae7... oeqa/selftest/recipetool: appendsrc: add test for update mode
    applied f8140d329655... linux-yocto/6.5: cfg: split runtime and symbol debug
    applied 0020b23900da... linux-yocto/6.5: update to v6.5.11
    applied e876d3bcd3f3... linux-yocto/6.1: update to v6.1.62
    applied 0947d61e3d9e... linux-yocto-dev: bump to v6.7
    applied baa9a89ef4ea... linux-yocto/6.5: update to v6.5.12
    applied b2b38e54792c... linux-yocto/6.5: update to v6.5.13
    applied 1cd02effb06f... linux-yocto/6.1: update to v6.1.65
    applied 72342e8eea49... linux-yocto: update CVE exclusions
    applied 959b1f7de437... gdb/systemd: enable minidebuginfo support conditionally
    applied 2b32e0fd6e6d... tiff: Backport fixes for CVE-2023-6277
    applied 4bfbe2cffb51... linux-firmware: Package iwlwifi .pnvm files
    applied bfae97c50dcb... linux-firmware: Change bnx2 packaging
    applied fd2c56099712... linux-firmware: Create bnx2x subpackage
    applied 7d06e4e30b39... genericx86: remove redundant assignments
    applied 36b66553a734... image-uefi.conf: Add EFI_UKI_PATH variable
    applied 5b153cc1155c... socat: 1.7.4.4 -> 1.8.0.0
    applied b44ec49ba028... man-db: 2.11.2 -> 2.12.0
    applied e2165e26db21... update_gtk_icon_cache: Fix for GTK4-only builds
    applied 38d94c34a199... zstd: fix LICENSE statement
    applied aadd15d13c71... go: update 1.20.10 -> 1.20.11
    applied 75b799635d8e... go: update 1.20.11 -> 1.20.12
    applied 331f78ecc26d... oeqa/selftest/devtool: Correct git clone of local repository
    applied 389ef0d9e476... oeqa/selftest/devtool: Avoid global Git hooks when amending a patch
    applied 99bc21953a23... oeqa/selftest/devtool: Make test_devtool_load_plugin more resilient
    applied 7481f8e9168e... oeqa/selftest/recipetool: Make test_recipetool_load_plugin more resilient
    applied 3ef9ea88f15c... lib/oe/recipeutils: Avoid wrapping any SRC_URI[sha*sum] variables
    applied decf6e66dfe3... recipetool: create: Improve identification of licenses
    applied 45d2f8d4bc2c... recipetool: create: Only include the expected SRC_URI checksums
    applied dd2fb8f00ace... devtool: upgrade: Update all existing checksums for the SRC_URI
    applied 9a5c1456ba90... devtool: modify: Make --no-extract work again
    applied a8f959a8d315... cargo: Rename MANIFEST_PATH -> CARGO_MANIFEST_PATH
    applied e1931b5e0ec4... oeqa/selftest/recipetool: stop looking for md5sum
    applied fcd9f34dccdc... sanity.conf: Require bitbake 2.6.1 for recent runqueue change
    applied f73e52dd7115... sstate: Remove unneeded code from setscene_depvalid() related to useradd
    applied 1b14962c3fae... oeqa/runtime/systemd: Ensure test runs only on systemd images
    applied ad2f5a359e73... bitbake: toaster/tests: Update build test
    applied f6cc0b360f5d... bitbake: toaster/tests: Ensure to kill toaster process create for tests functional
    applied 49128ef8bad4... bitbake: toaster/tests: Added functional/utils, contains useful methods using by functional tests
    applied d5a6e3b546e7... bitbake: toaster/tests: Refactorize tests/functional
    applied 23d3e2c718d6... bitbake: toaster/tests: Bug fixes, functional tests dependent on each other
    applied 6d9122565157... bitbake: toaster/tests: Fixes warnings in autobuilder
    applied 7fefb8588894... bitbake: toaster/tests: bug-fix tests writing files into /tmp on the autobuilders
    applied d14eb12deb62... bitbake: utils: Do not create directories with ${ in the name
    applied ecef665062be... useradd: Fix issues with useradd dependencies
    applied e3ce7ce2158c... useradd: Add testcase for bugzilla issue (currently disabled)
    applied e70f491b7eb2... usergrouptests.py: Add test for switching between static-ids
    applied 4d14176aa69d... bitbake: toaster: Update to use qemux86-64 machine by default
    applied b32dbb3747ba... bitbake: toaster/tests/builds: Add BB_HASHSERVE passthrough
    applied b3d1a7297fb8... pseudo: Update to pull in syncfs probe fix
    applied 97a7fe536d3f... selftest/sstatetest: print output from bitbake with actual newlines, not \n
    applied 3befa37ae76e... selftest/sstatetests: do not delete custom $TMPDIRs under build-st when testing printdiff
    applied 95c187e54e2d... sstatesig/find_siginfo: special-case gcc-source when looking in sstate caches
    applied 78ef0313ee6a... recipetool: pypi: do not clobber SRC_URI checksums
    applied c2f44a6e9739... images: remove redundant IMAGE_BASENAME assignments
    applied 0b4a4952e145... insane: ensure more paths have the workdir removed
    applied db73316fea6b... bluez5: fix CVE-2023-45866
    applied 43df94f7af84... cargo: Move CARGO_MANIFEST_PATH/CARGO_SRC_DIR to cargo_common
    applied dddfe1e3f413... rust: cargo: Convert single-valued variables to weak defaults
    applied 6543d3c5e9fc... cargo: Add CARGO_LOCK_PATH for path to Cargo.lock
    applied 61805f6d60a3... oeqa/selftest/bbtests: Add test for unexpanded variables in the dirname
    applied 4bb222e0d71a... useradd: Fix useradd do_populate_sysroot dependency bug
    applied df5c8d6471bf... bitbake: toaster: Added new feature to import eventlogs from command line into toaster using replay functionality
    applied effe2498ebec... bitbake: toaster: Add verbose printout for missing chrome(driver) dependencies
    applied a9317426777e... musl: add typedefs for Elf64_Relr and Elf32_Relr
    applied 2d7cea74d75f... python3-setuptools-rust: BBCLASSEXTEND + nativesdk
    applied 01e845576829... base: Unpack .7z files with p7zip
    applied 1d19f6c52739... tcl: skip timing-dependent tests in run-ptest
    applied b9eeb3b3863f... qemurunner: remove unused import
    applied b8bbd1ca9311... kmod: Fix build with latest musl
    applied 52ec79a6d305... elfutils: Use own basename API implementation
    applied 86a377ebe788... util-linux: Fix build with latest musl
    applied ad645dc8b273... sysvinit: Include libgen.h for basename API
    applied bebebac37d3a... attr: Fix build with latest musl
    applied ef371d1cb3b7... cve-update-nvd2-native: faster requests with API keys
    applied 0ce61d9b8b6d... cve-update-nvd2-native: increase the delay between subsequent request failures
    applied c39adf61d3d4... opkg: Use own version of portable basename function
    applied f32178a2465a... oeqa/selftest/recipetool: add back checksum checks on pypi tests
    applied 7cf0c3009691... go: set vendor in CVE_PRODUCT
    applied b3f6a6d87dfb... nfs-utils: Upgrade 2.6.3 -> 2.6.4
    applied bb0566eafd25... archiver.bbclass: Improve work-shared checking
    applied 94c4d9e35f14... oeqa/selftest/recipetool: remove left over from development
    applied 5d6a41b265ca... oeqa/selftest/recipetool: fix metadata corruption on meta layer
    applied 8a7dffc2789a... bitbake: toaster/test: fix Copyright
    applied 799c131d9202... bitbake: toaster: remove test and update setup to avoid rebuilding image
    applied dc608a5bbedb... bitbake: bitbake: toaster: add functional testing toaster error details
    applied 7a20381430f7... rust: Disable rust oe-selftest
    applied 93292feac47b... rust: Upgrade 1.70.0 -> 1.71.0
    applied 66ba89328565... rust: Upgrade 1.71.0 -> 1.71.1
    applied d7c05e4eed4e... cmake-qemu.bbclass: make it more usable
    applied 2df986746b40... oe-selftest: add a cpp-example recipe
    applied 1ec91141e5a0... oeqa/core/decorator: add skip if not qemu-usermode
    applied 85f84b4090f3... oe-selftest: add tests for C and C++ build tools
    applied 524255ad266c... bitbake: toaster: Commandline build import table improvements
    applied 942f0909f38c... runqemu: add qmp socket support
    applied 47cc6288280b... sstate: Fix dir ownership issues in SSTATE_DIR
    applied e9c2003bd080... bitbake: toaster/tests: Exit tests on chromedriver creation failure
    applied e63d6cb38ef6... bitbake: toaster/tests: fix functional tests setup and teardown
    applied 0fd93b86c46d... bitbake: toaster/tests: fix chrome argument syntax and wait for driver exit
    applied 5648636a8b5c... bitbake: toaster/tests: logging warning in console, trying to kill unavailable Runbuilds process
    applied c8382b35e843... bitbake: toaster/tests: Removed all time.sleep occurrence
    applied 81a0110ca532... bitbake: toaster/tests: Bug-Fix testcase functional/test_project_page_tab_config.py
    applied adb7efe52207... bitbake: toaster/tests: bug-fix element click intercepted in browser/test_layerdetails_page.py
    applied ad2ffefb147f... bitbake: toaster/tests: Update tests/functional/functional_helpers test_functional_basic
    applied a02138ad48a9... bitbake: toaster/tests: Fixes functional tests warning on autobuilder
    applied 6ce61b435705... strace: Disable bluetooth support by default
    applied 83cad97561cb... util-linux: Delete md-raid tests
    applied 53d45455a224... devtool: modify: Handle recipes with a menuconfig task correctly
    applied ff7aba28f707... bitbake: toaster: Added validation to stop import if there is a build in progress
    applied 26edf895615b... oeqa/sstatetests: Disable gcc source printdiff test for now
    applied 5815ccc1f6fd... build-appliance-image: Update to master head revision
    applied e706249f7b68... bitbake: utils: Fix mkdir with PosixPath
    applied 69a4180c88dd... bitbake: runqueue: Remove tie between rqexe and starts_worker
    applied 6e6bb93fda59... oeqa/selftest/sstatetests: re-work CDN tests, add local cache tests
    applied d97636a0e53d... python3-maturin: add v1.4.0
    applied c5cd7c5900bd... python3-maturin: bzip2-sys reproduciblility
    applied ca5427280d91... classes-recipe: add python_maturin.bbclass
    applied 9707dc5549b6... recipetool: add python_maturin support
    applied 844e91049c81... oe-selfest: add maturn runtime (testimage) test
    applied b2b2e0277509... oeqa: add simple 'maturin' SDK (testsdk) test case
    applied 7d881f0214f9... oeqa: add "maturin develop" SDK test case
    applied a49de3ccc11f... create-spdx-2.2: combine spdx can try to write before dir creation
    applied 490b94c3b530... bitbake: bitbake-hashserv: Add description of permissions
    applied 33112178d164... build-appliance-image: Update to master head revision
    applied c24e3b9f676e... dev-manual: Discourage the use of SRC_URI[md5sum]
    applied 84b242ef8bc1... test-manual: text and formatting fixes
    applied 3090312661eb... test-manual: resource updates
    applied 51c390571f32... test-manual: use working example
    applied 98ee926e2c52... test-manual: add links to python unittest
    applied d9be74b13f40... test-manual: explicit or fix file paths
    applied bd8f3acd1438... test-manual: add or improve hyperlinks
    applied a1ae83c59b09... manuals: document minidebuginfo
    applied ede920cb03e1... migration-guides: reword fix in release-notes-4.3.1
    applied 401bc1480a4b... manuals: brief-yoctoprojectqs: align variable order with default local.conf
    applied d59a8b7f463a... dev-manual: runtime-testing: fix test module name
    applied 17ce33958140... migration-guides: add release notes for 4.0.15
    applied 2ad23af63be4... linux-yocto: update CVE exclusions
    applied 1c5edf4b2158... sqlite3: upgrade 3.44.0 -> 3.44.2
    applied a1f912e4d8de... base-passwd: upgrade 3.6.2 -> 3.6.3
    applied 0656a5d89df7... bluez5: upgrade 5.70 -> 5.71
    applied 6a47da632e45... glib-2.0: upgrade 2.78.1 -> 2.78.3
    applied a5fc5b14a19c... glib-networking: upgrade 2.76.1 -> 2.78.0
    applied e104ef373687... puzzles: upgrade to latest revision
    applied 6ce7d6dd4e2d... stress-ng: upgrade 0.17.01 -> 0.17.03
    applied 2e65519ee792... libusb1: fix upstream version check
    applied 55ff0c2bf9a2... enchant2: upgrade 2.6.2 -> 2.6.4
    applied 255e165c601b... tcl: skip async and event tests in run-ptest
    applied 8dff71863335... bitbake.conf: Add runtimedir
    applied db2ae4211ade... rpcbind: Specify state directory under /run
    applied 378a553dc701... systemtap: explicit handling debuginfod library dependency
    applied e428775da965... systemtap: fix libdebuginfod auto detection logic
    applied 038d364992da... testimage: Exclude wtmp from target-dumper commands
    applied d921da782aed... qemurunner: Improve stdout logging handling
    applied 98b63ecc4358... qemurunner: Improve handling of serial port output blocking
    applied 2ad6a0be02ac... oeqa/selftest/overlayfs: Don't overwrite DISTRO_FEATURES
    applied 08369812c1a9... testimage: Drop target_dumper and most of monitor_dumper
    applied 98214f1bc2cd... bitbake: toaster/tests: Bug-fix test_functional_basic, delay driver actions
    applied 191645f746b0... oeqa/selftest/overlayfs: Fix whitespace
    applied 1720dae4ed5b... bitbake: toastergui: verify that an existing layer path is given
    applied baa6b64a9466... poky.conf: update SANITY_TESTED_DISTROS to match autobuilder
    applied b60f98d3fd56... gdb: Update to gdb 14.1 release
    applied 3a881b672d26... perlcross: update to 1.5.2
    applied 56a22eb31c25... perl: 5.38.0 -> 5.38.2
    applied 26560efaeabb... images: add core-image-initramfs-boot
    applied 5800c6a60fde... systemd: Fix build with latest musl
    applied 53af03827e0c... qemu: Fix build with latest musl
    applied 194ffa6fea6e... qemu: Add packageconfig knob to enable pipewire support
    applied 2f56aec05c58... machine/arch-armv9: remove crc and sve tunes, they are mandatory
    applied e73b3744dea8... python3: re-enable profile guided optimisation
    applied 7cac39b4a238... weston: Include libgen.h for basename
    applied 1d4447abb979... gobject-introspection: depend on setuptools to obtain distutils module
    applied 05d187fec3bd... libcap-ng-python: depend on setuptools to obtain distutils copy
    applied 398b979449fb... dnf: remove obsolete python3-gpg dependency (provided by gpgme)
    applied 143686fe4869... gpgme: disable python support (until upstream fixes 3.12 compatibility)
    applied 8c67164341d8... python3-setuptools-rust: remove distutils dependency
    applied e99732267add... python3-babel: replace distutils with setuptools, as supported by upstream
    applied 504651f85371... python3-pip: remove distutils depedency
    applied 028c318f7cfe... glib-2.0: replace distutils dependency with setuptools
    applied 91f9f75e1bdb... python3-pytest-runner: remove distutils dependency
    applied 2c1b967cd1b2... python3-numpy: distutils is no longer required
    applied ab621df9f52a... mesa: upgrade 23.2.1 -> 23.3.1
    applied 16a3fde3fa77... nfs-utils: Update Upstream-Status
    applied bc8ca0bacc91... wic: use E2FSPROGS_FAKE_TIME and hash_seed to generate reproducible ext4 images
    applied a84a8ac625ef... python3-license-expression: Fix the ptest failure
    applied b1ff67062a5a... ptest-packagelists.inc: Add python3-license-expression
    applied b2585b54b1af... dtc: preserve version also from shallow git clones
    applied 3c26d5181a77... libinput: Add packageconfig for tests
    applied 198d891baa5d... avahi: backport CVE-2023-1981 & CVE's follow-up patches
    applied 92fd81b7dee5... openssl: mark assembler sections as call targets for PAC/BTI support on aarch64
    applied 321aebfa281b... rust: rustdoc reproducibility issue fix - disable PGO
    applied 85c88f833250... qemu: Clean up DEPENDS
    applied c270131c530e... qemu: Ensure pip and the python venv aren't used for meson
    applied 4a5ef39d8a6a... qemurunner: more cleanups for output blocking
    applied 6ad00a5bd634... curl: update to 8.5.0
    applied b92406d23132... curl: Disable two intermittently failing tests
    applied f6a65eb791ee... kbd: upgrade 2.6.3 -> 2.6.4
    applied 752425b8c485... libatomic-ops: upgrade 7.8.0 -> 7.8.2
    applied 3fb535af268a... libnl: upgrade 3.8.0 -> 3.9.0
    applied 4d7f5a305c53... libseccomp: upgrade 2.5.4 -> 2.5.5
    applied 3b5f6005a2b0... libva-utils: upgrade 2.20.0 -> 2.20.1
    applied 54bd979f70c8... dnf: upgrade 4.18.1 -> 4.18.2
    applied 147450c82339... gpgme: upgrade 1.23.1 -> 1.23.2
    applied b55f951cd77e... kea: upgrade 2.4.0 -> 2.4.1
    applied a856192be5dd... opkg-utils: upgrade 0.6.2 -> 0.6.3
    applied 170e3d116f59... repo: upgrade 2.39 -> 2.40
    applied 53e39c1063a6... sysstat: upgrade 12.7.4 -> 12.7.5
    applied 38f7a143f6f0... p11-kit: upgrade 0.25.2 -> 0.25.3
    applied aaaf4043540e... python3-babel: upgrade 2.13.1 -> 2.14.0
    applied bb4eea1ffcbd... python3-dbusmock: upgrade 0.29.1 -> 0.30.0
    applied 052b0366807f... python3-hatchling: upgrade 1.18.0 -> 1.20.0
    applied 7462974f022a... python3-hypothesis: upgrade 6.90.0 -> 6.92.1
    applied 8e5acb3cc872... python3-importlib-metadata: upgrade 6.8.0 -> 7.0.0
    applied 3466cab0ab9c... python3-license-expression: upgrade 30.1.1 -> 30.2.0
    applied 97d72a8d3409... python3-pathspec: upgrade 0.11.2 -> 0.12.1
    applied a0105d85b42d... python3-pip: upgrade 23.3.1 -> 23.3.2
    applied 1b8c0a3095ef... python3-psutil: upgrade 5.9.6 -> 5.9.7
    applied d3c802bcbea8... python3-pytest-runner: upgrade 6.0.0 -> 6.0.1
    applied b15fb09ecd12... python3-trove-classifiers: upgrade 2023.11.22 -> 2023.11.29
    applied 352388c1098e... python3-typing-extensions: upgrade 4.8.0 -> 4.9.0
    applied cde69036a495... python3-wcwidth: upgrade 0.2.11 -> 0.2.12
    applied b2b15c137332... ttyrun: upgrade 2.29.0 -> 2.30.0
    applied 9cd6986348be... xwayland: upgrade 23.2.2 -> 23.2.3
    applied dfe9c4526492... oeqa: add runtime 'maturin develop' test case
    applied df548e981da9... ipk: Switch to using zstd compression
    applied deab1148b39b... diffoscope: upgrade 252 -> 253
    applied 62e87836c419... debianutils: upgrade 5.14 -> 5.15
    applied 53b8ae267941... devtool: deploy: provide max_process to strip_execs
    applied d59c3c718a5a... ncurses: Fix - tty is hung after reset
    applied a22f7d7b533c... lib/oe/path.py: Add relsymlink()
    applied 72b6728f8241... lib/packagedata.py: Fix broken symlinks for providers with a '/'
    applied 48f4dd4a0c65... libadwaita: update 1.4.0 -> 1.4.2
    applied 0b3cea1baa3a... appstream: Upgrade 0.16.3 -> 1.0.0
    applied b5a465e61480... man-pages: remove conflict pages
    applied 60ce68180a6b... nativesdk: ensure features don't get backfilled
    applied 64162b18127c... nativesdk: don't unset MACHINE_FEATURES, let machine-sdk/ set it
    applied 3000abe20af5... conf/machine-sdk: declare qemu-usermode SDK_MACHINE_FEATURE
    applied 7608ad08ae67... image-live.bbclass: LIVE_ROOTFS_TYPE support compression
    applied df9829d710dd... linux-yocto/6.1: drop removed IMA option
    applied b574de9c4d77... linux-yocto/6.5: drop removed IMA option
    applied 5ad156a939ab... linux-yocto-rt/6.1: update to -rt18
    applied e369c3bb2f6b... linux-yocto/6.1: update to v6.1.66
    applied b9c8befbb895... linux-yocto/6.1: update to v6.1.67
    applied 1f246f28d7b2... linux-yocto/6.5: fix AB-INT: QEMU kernel panic: No irq handler for vector
    applied afb5193989f7... linux-yocto/6.1: update to v6.1.68
    applied 447ca52429fa... linux/cve-exclusion6.1: Update to latest kernel point release
    applied 7b663133a68e... libdrm: Upgrade to 2.4.119
    applied 0d9de34ac677... python3-maturin: Add missing space appending to CFLAGS
    applied fdef56a596b9... archiver.bbclass: Drop tarfile module to improve performance
    applied 34bafb3cf271... bitbake: contrib/vim: Syntax improvements
    applied 23549b87c597... uninative-tarball.xz - reproducibility fix
    applied 2ef4bf954b4f... classes-global/sstate: Fix variable typo
    applied af61f98f0034... libseccomp: remove redundant PV assignment
    applied dd5475d8e38f... lib/packagedata.py: Add API to iterate over rprovides
    applied cd125f1703fc... classes-global/insane: Look up all runtime providers for file-rdeps
    applied 52f41ff24303... lib/prservice: Improve lock handling robustness
    applied 2d8e0802313d... oeqa/selftest/prservice: Improve test robustness
    applied b723fcaac52f... sstate-cache-management: Rewrite in python
    applied acf45e764ca4... package.py: OEHasPackage: Add MLPREFIX to packagename
    applied 6ce42d73a31b... scripts: Drop shell sstate-cache-management
    applied 87b237512f0c... oeqa/selftest/sstatetests: Update sstate management script tests to python script
    applied 9e0cccb651e8... tzdata: Upgrade to 2023d
    applied faae19bca0e4... iputils: upgrade 20221126 -> 20231222
    applied ca78b23f5751... gstreamer1.0: upgrade 1.22.7 -> 1.22.8
    applied c541bd3f3cc1... dhcpcd: upgrade 10.0.5 -> 10.0.6
    applied a0841ca7ae4d... fontconfig: upgrade 2.14.2 -> 2.15.0
    applied 775c1cc08b6b... python3-setuptools: upgrade 69.0.2 -> 69.0.3
    applied 885c1a41d9f1... python3-dbusmock: upgrade 0.30.0 -> 0.30.1
    applied c0484c2ed01d... python3-hatchling: upgrade 1.20.0 -> 1.21.0
    applied da2d5a090f93... python3-importlib-metadata: upgrade 7.0.0 -> 7.0.1
    applied 64c4a5024fdd... python3-lxml: upgrade 4.9.3 -> 4.9.4
    applied 85d3de0b8aab... curl: Disable test 1091 due to intermittent failures
    applied f87f7e1b8c5c... devtool: selftest: Fix test_devtool_modify_git_crates_subpath inequality
    applied 6bc41cf96f6b... devtool: selftest: Fix test_devtool_modify_git_crates_subpath bbappend check
    applied 781bd05a4bc4... meta-selftest: hello-rs: Simple rust test recipe
    applied 93f71a076c13... devtool: selftest: Swap to hello-rs for crates testing
    applied b40a8e02084b... zvariant: Drop recipe
    applied 6eabf7e4b411... rust: Upgrade 1.71.1 -> 1.72.0
    applied aa0b0d0cc269... rust: Upgrade 1.72.0 -> 1.72.1
    applied 537ed2b654bb... rust: Upgrade 1.72.1 -> 1.73.0
    applied 8fd396bc3dc1... rust: Upgrade 1.73.0 -> 1.74.0
    applied f00d4c302906... rust: Upgrade 1.74.0 -> 1.74.1
    applied fe5d2f0b666c... bitbake: lib/bb: Add workaround for libgcc issues with python 3.8 and 3.9
    applied c8f08af400ac... kmscube: Upgrade to latest revision
    applied 1b4f19bae896... autoconf: Add missing perl modules to RDEPENDS
    applied 4f2c4993ef9e... systemd-boot: Add recipe to compile native
    applied 4b7e54846392... aspell: upgrade 0.60.8 -> 0.60.8.1
    applied 6a67f2477311... bitbake: toaster/tests: bug-fix An element matching "#projectstable" should be visible
    applied 3e6d3817da54... bitbake: toaster/tests: bug-fix An element matching "#lastest_builds" should be on the page
    applied 350300f83629... bitbake: toaster/tests: Skip to show more then 100 item in ToasterTable
    applied 280917c2e70b... bitbake: toaster/tests: Bug-fix "#project-created-notification" should be visible
    applied 39581827102c... bitbake: bitbake/codeparser.py: address ast module deprecations in py 3.12
    applied 97306ebc00ef... beaglebone-yocto: Remove the redundant kernel-devicetree
    applied 5d7a4304d918... beaglebone-yocto: Remove the obsolete variables for uImage
    applied 70a92a2f8bfd... patchtest: Add test for deprecated CVE_CHECK_IGNORE
    applied bd05979aa833... devtool: use straight print in check-upgrade-status output
    applied 3c71605a7780... scripts/runqemu: fix regex escape sequences
    applied cddf8e9f53df... sanity.bbclass: Check for additional native perl modules.
    applied 30e0c90f3076... glibc-y2038-tests: do not run tests using 32 bit time APIs
    applied e08a0caab4cc... tcp-wrappers: drop libnsl2 build dependency
    applied 361cc39ede48... grub: fs/fat: Don't error when mtime is 0
    applied 5589031867e4... bmap-tools: Upgrade to 3.7
    applied d68492d6c5f9... oeqa/runtime/parselogs: add qemux86 ACPI ignore for kernel v6.6+
    applied 1bbdc674aef8... inetutils: Update to the 2.5 release
    applied b0e66c9acf2b... linux-libc-headers: update to v6.6-lts
    applied df9eb69f3e4b... linux-yocto: introduce 6.6 reference kernel
    applied f7ea203fad62... linux-yocto/6.6: fix AB-INT: QEMU kernel panic: No irq handler for vector
    applied d18436b6cf8a... linux-yocto-rt/6.6: fix CVE exclusion include
    applied a6c2ab1a88d4... linux-yocto/6.6: update CVE exclusions
    applied 470463ae2e2d... linux-yocto/6.6: update to v6.6.8
    applied e0062e12b5c1... linux-yocto/6.1: update to v6.1.69
    applied 1a364657210a... linux-yocto/6.5: drop 6.5 recipes
    applied b21b467e7832... linux-yocto-rt/6.6: correct meta data branch
    applied 486588e2ae89... linux-yocto/6.6: update to v6.6.9
    applied a8e54cc7068e... linux-yocto/6.6: update CVE exclusions
    applied 10075b25626b... linux-yocto/6.1: update to v6.1.70
    applied 2a99029835fb... linux-yocto/6.1: update CVE exclusions
    applied 102927a5272a... linux-yocto/6.6: ARM fix configuration audit warning
    applied 812dbc2769f8... linux-yocto/6.6: arm: jitter entropy backport
    applied 936783534652... oeqa/parselogs-ignores-qemuarmv5: add comments and organise
    applied 54f9db951abd... lib/bblayers/makesetup.py: Remove unused imports
    applied 01ef197c6b3f... lib/bblayers/buildconf.py: Remove unused imports/variables
    applied 339ccc0c2bd2... runqemu: match .rootfs. in addition to -image- for rootfs
    applied da7384a8e99a... poky/poky-tiny: make 6.6 the default kernel
    applied 831b3d5b2213... bitbake: toaster/toastergui: Bug-fix verify given layer path only if import/add local layer
    applied b0c47ae55552... bitbake: bitbake/runqueue: add debugging for find_siginfo() calls
    applied a41b54ccbd90... bitbake: bitbake: Post release version bump to 2.7.0
    applied cc85c8eb9d96... bitbake: bitbake-diffsigs/runqueue: adapt to reworked find_siginfo()
    applied 859786a83f8b... bitbake: siggen: Ensure version of siggen is verified
    applied 7d400f94fee6... bitbake: bitbake/runqueue: prioritize local stamps over sstate signatures in printdiff
    applied 71c0d311baad... bitbake: bitbake: Version bump for find_siginfo chanages
    applied c45ffa9e9489... sstatesig/find_siginfo: unify a disjointed API
    applied a7aa37f2fd9b... sstatesig: Add version information for find_sigingfo
    applied 871b000464ad... sanity: Require bitbake 2.7.1
    applied 4675bbb757a4... lib/sstatesig/find_siginfo: raise an error instead of returning None when obtaining mtime
meta-openembedded 5ad7203f68 -> 7d8115d550:
    applied 3befc1a4af63... jasper: upgrade 2.0.33 -> 4.1.1
    applied bcc76585519c... poco: upgrade 1.12.4 -> 1.12.5p2
    applied 952f79330eb2... xcursorgen: upgrade 1.0.7 -> 1.0.8
    applied 40daa8ca7c6c... xstdcmap: upgrade 1.0.4 -> 1.0.5
    applied 5b20a3c8f2b5... xlsclients: upgrade 1.1.4 -> 1.1.5
    applied f0a0c85b75af... xlsatoms: upgrade 1.1.3 -> 1.1.4
    applied 709484dd7424... xkbevd: upgrade 1.1.4 -> 1.1.5
    applied b86d42b95120... xgamma: upgrade 1.0.6 -> 1.0.7
    applied 5ec9943b2d67... sessreg: upgrade 1.1.2 -> 1.1.3
    applied 61cd30fc786f... sip: Upgrade 6.7.12 -> 6.8.0
    applied 0cda5a8fb9fb... monocypher: pass LIBDIR to fix installed-vs-shipped QA issue with multilib
    applied f95ba6d0742a... wireplumber: update 0.4.15 -> 0.4.17
    applied 5430b16813c8... xbitmaps: upgrade 1.1.2 -> 1.1.3
    applied da5e4c5eb2f0... xcursor-themes: add recipe
    applied 02f460c5e379... lvm2: 2.03.16 -> 2.03.22
    applied 90e272d06cf9... xorg-docs: add recipe
    applied 959f6a5da8e1... xorg-sgml-doctools: update summary depends and inc file
    applied 689d87cd1fda... xf86-video-ati: upgrade 19.1.0 -> 22.0.0
    applied 0cbede2b2529... xf86-input-void: upgrade 1.4.1 -> 1.4.2
    applied 97f91bdbb0cd... libxaw: upgrade 1.0.14 -> 1.0.15
    applied d6f689da36fe... mutter: Make gnome-desktop and libcanberra dependencies optional
    applied e351a50f8b00... python3-flask-sqlalchemy: upgrade 2.5.1 -> 3.1.1
    applied e7c94af6b2ef... ostree: Upgrade 2023.7 -> 2023.8
    applied f3c7c83bf40c... xf86-video-mga: upgrade 2.0.0 -> 2.0.1
    applied 190f7b50ac3d... abseil-cpp: remove -Dcmake_cxx_standard=14 flag from extra_oecmake
    applied 0f0c4c96d90d... snappy: upgrade 1.1.9 -> 1.1.10
    applied 0f9e5d1f9b62... zenity: Upgrade to 4.0.0
    applied f60e4bfcbee6... terminus-font: build compressed archives with -n
    applied 1a84a1ebbe19... xsetroot: upgrade 1.1.2 -> 1.1.3
    applied 9ae31f6f6a67... Remove unused SRC_DISTRIBUTE_LICENSES
    applied 58194b0b1264... gspell: inherit gtk-doc
    applied c3eaf805d2cc... gspell: update DEPENDS, switch iso-codes for icu
    applied 069885e74dac... librest: remove spurious build dependencies
    applied a9cee7a46934... librest: inherit gtk-doc
    applied 21dbf20b5402... keybinder: use autotools-brokensep instead of setting B
    applied d015d52ad811... keybinder: disable gtk-doc documentation
    applied f8f5c728a387... gtksourceview3: remove obsolete DEPENDS
    applied 103f49b5fc98... libgsf: remove obsolete DEPENDS
    applied 50769bc2f25f... evolution-data-server: remove obsolete intltool DEPENDS
    applied 602306d4bdfd... tracker: dont inherit gsettings
    applied cdaafdea99c6... rygel: fix build with gtk+3 PACKAGECONFIG disabled
    applied 23b62b3391f2... rygel: add x11 to DISTRO_FEATURES
    applied 90976455c1f2... android-tools: remove two Debianisms
    applied adecc463a3c0... minifi-cpp: Fix do_configure error builder aarch64
    applied b145fdac545f... libbytesize: Removed unnecessary setting of B
    applied bfda5e7c70da... libmxml: use autotools-brokensep instead of setting B
    applied 763fd809cf8f... libsombok3: use autotools-brokensep instead of setting B
    applied 0a0ea87b8dda... pgpool2: use autotools-brokensep instead of setting B
    applied 5f76240e8810... jasper: enable opengl only wih x11
    applied 26795b690a45... python3-greenlet: update to version 3.0.2
    applied 666908092fd2... python3-ujson: update to version 5.9.0
    applied 2840fcf18dd6... python3-termcolor: update to version 2.4.0
    applied 2e864f1e201c... python3-cmake: update to version 3.28.0
    applied 82523b1fff87... python3-pint: upgrade to 0.23
    applied 101bb00d877c... python3-gnupg: update to 0.5.2
    applied 90393ce5153f... python3-pyzmq: update to 25.1.2
    applied 97c2b0d2d52b... python3-tox: update to version 4.11.4
    applied 41fef651c04b... python3-olefile: update to version 0.47
    applied debcb9a7d0da... python3-distlib: update to version 0.3.8
    applied 0d2ddca3352f... python3-colorlog: update to version 6.8.0
    applied 9b0bc6bf3c7b... python3-pymongo: update version to 4.6.1
    applied e028b409ea99... python3-bandit: update to version 1.7.6
    applied 4497eb3096d8... python3-gmqtt: update to version 0.6.13
    applied 1b849b6ded20... python3-portion: update to version 2.4.2
    applied b809d4dd2161... python3-prompt-toolkit: update to version 3.0.43
    applied 8f276a9bae3c... python3-asyncinotify: update to version 4.0.4
    applied e650892546d0... python3-bitstring: update to version 4.1.4
    applied 660144e48c82... python3-ipython: update to version 8.18.1
    applied c66374a507ea... python3-alembic: upgrade 1.12.1 -> 1.13.0
    applied 52126fbc3398... python3-ansi2html: upgrade 1.8.0 -> 1.9.1
    applied 02e3123e6893... python3-argcomplete: upgrade 3.1.6 -> 3.2.1
    applied 8ab2bc33d31f... python3-dbus-fast: upgrade 2.15.0 -> 2.21.0
    applied 532ba5518af7... python3-django: upgrade 4.2.7 -> 5.0
    applied eaa7d950ed3b... python3-flask-restx: upgrade 1.2.0 -> 1.3.0
    applied 186765ab8d55... python3-google-api-core: upgrade 2.14.0 -> 2.15.0
    applied cd7ab6db720f... python3-google-api-python-client: upgrade 2.108.0 -> 2.111.0
    applied 2e0a01b9cf72... python3-googleapis-common-protos: upgrade 1.61.0 -> 1.62.0
    applied 4cac6ad7b958... python3-google-auth: upgrade 2.23.4 -> 2.25.2
    applied 6cfdc2581a4e... python3-imageio: upgrade 2.33.0 -> 2.33.1
    applied 36df077879a3... python3-isort: upgrade 5.12.0 -> 5.13.1
    applied 5958fdd6f519... python3-path: upgrade 16.7.1 -> 16.9.0
    applied de364d91e4ad... python3-platformdirs: upgrade 4.0.0 -> 4.1.0
    applied 616fb9ccb7c6... python3-pytest-asyncio: upgrade 0.22.0 -> 0.23.2
    applied 6c98ed4d1af6... python3-sentry-sdk: upgrade 1.37.1 -> 1.39.0
    applied 702cf1dc114d... mariadb: Upgrade to 10.11.6
    applied dc4bef4648ea... nginx: upgrade 1.25.2 -> 1.25.3
    applied b0bc64e93085... networkmanager: Improved SUMMARY and added DESCRIPTION
    applied 02e05067e826... python3-bitarray: upgrade 2.8.3 -> 2.8.5
    applied 8dc77ebf92fe... nginx: update versions for both the stable branch and mainline
    applied af57a19214fd... python3-portalocker: update to version 2.8.2
    applied f17d0272735b... python3-eth-keyfile: upgrade 0.6.1 -> 0.7.0
    applied 8ec035da44d6... python3-eth-rlp: upgrade 0.3.0 -> 1.0.0
    applied 236bf067d420... python3-fastnumbers: upgrade 5.0.1 -> 5.1.0
    applied 6580c4bb38ec... python3-pylint: upgrade 3.0.2 -> 3.0.3
    applied e47aa62228fd... python3-tornado: upgrade 6.3.3 -> 6.4
    applied 1e42b157bd68... python3-traitlets: upgrade 5.13.0 -> 5.14.0
    applied e5852cf3a535... python3-types-setuptools: upgrade 68.2.0.2 -> 69.0.0.0
    applied f145529e61b4... python3-virtualenv: upgrade 20.24.7 -> 20.25.0
    applied 496776dedef9... python3-web3: upgrade 6.11.3 -> 6.12.0
    applied 3723fd45fa9d... python3-websocket-client: upgrade 1.6.4 -> 1.7.0
    applied 0fa5e4dfabc9... python3-zeroconf: upgrade 0.127.0 -> 0.128.4
    applied afb65e9e1823... ctags: upgrade 6.0.20231126.0 -> 6.0.20231210.0
    applied 851b1777afe6... gensio: upgrade 2.8.0 -> 2.8.2
    applied 166902731656... hwdata: upgrade 0.376 -> 0.377
    applied 3f441ef0d172... lvgl: upgrade 8.3.10 -> 8.3.11
    applied 7b5fe50d04cc... gjs: upgrade 1.78.0 -> 1.78.1
    applied cc8256777072... ifenslave: upgrade 2.13 -> 2.14
    applied 5fccac2c22d4... libei: upgrade 1.1.0 -> 1.2.0
    applied 7f858e4f54de... pkcs11-helper: upgrade 1.29.0 -> 1.30.0
    applied 029da4ea7476... python3-pyinotify: remove as unmaintained
    applied e45c13134c46... python3-supervisor: do not rely on smtpd module
    applied 10e44c9ce5b9... python3-meld3: do not rely on smtpd module
    applied 6de5e84625c9... python3-m2crypto: do not rely on smtpd module
    applied b4efcecc63c8... python3-uinput: remove as unmaintained
    applied 7b927732c651... python3-mcrypto: rely on setuptools for distutils copy
    applied bd51af4c16cc... python3-joblib: do not rely in distutils
    applied ec7e44f97c32... python3-web3: remove distutils dependency
    applied a5a6b673d19a... python3-cppy: remove unused distutils dependency
    applied 70664268a41c... python3-pyroute2: remove unused distutils dependency
    applied 1ae3d1fe6aea... python3-eventlet: backport a patch to remove distutils dependency
    applied 19378a686b26... python3-unoconv: rely on setuptools to obtain distutils copy
    applied 5c725616cd93... python3-astroid: remove unneeded distutils dependency
    applied 864f16d68665... python3-django: remove unneeded distutils dependency
    applied a293a7128af8... python3-pillow: remove unneeded distutils dependency
    applied d595b18e4691... python3-grpcio: update 1.56.2 -> 1.59.3
    applied 026721909a6f... gstd: correctly delete files in do_install
    applied d1c899315991... libplist: fix python 3.12 compatibility
    applied dd402176a6e2... libcamera: skip until upstream resolves python 3.12 compatibility
    applied f4bf27dbdb75... nodejs: backport (partially) python 3.12 support
    applied 122e937a0e0f... python3-expandvars: add recipe
    applied 8cb3c9b8db52... python3-frozenlist: upgrade 1.4.0 -> 1.4.1
    applied 038fd54f28eb... python3-yarl: upgrade 1.9.2 -> 1.9.4
    applied 01bafc3eeb61... python3-coverage: upgrade 7.3.2 -> 7.3.3
    applied 39ff8dc26c4c... python3-cycler: upgrade 0.11.0 -> 0.12.1
    applied c754b8ec0c75... python3-aiohue: upgrade 4.6.2 -> 4.7.0
    applied 882aaf9506fb... gnome-software: update 45.1 -> 45.2
    applied 5edb8335dc46... networkmanager: add missing modemmanager rdepends
    applied 5be2e20157f3... strongswan: upgrade 5.9.12 -> 5.9.13
    applied 1a474db2702c... webkitgtk3: upgrade 2.42.2 -> 2.42.3
    applied fa9122a2b8a2... sip: upgrade 6.8.0 -> 6.8.1
    applied 058f22ac2747... crash: factorize recipe with inc file to prepare cross-canadian version
    applied 1f9ad22b28c2... crash: add cross canadian version
    applied a4031df72d4b... crash: update to 8.0.4
    applied 3f844d4136cf... paho-mqtt-cpp: upgrade 1.3.1 -> 1.3.2
    applied 7a7f975f6bf0... mdns: Fix HOMEPAGE URL
    applied ebe950c8e9c8... mbedtls: Upgrade 3.5.0 -> 3.5.1
    applied a89917242d35... python3-sdbus: upgrade 0.11.0 -> 0.11.1
    applied c6ba2fcc4a46... python3-zeroconf: upgrade 0.128.4 -> 0.130.0
    applied 1d887eede793... python3-dominate: upgrade 2.8.0 -> 2.9.0
    applied fb7023bd3c20... python3-rlp: upgrade 3.0.0 -> 4.0.0
    applied 7e7f670f4b38... redis: Create state directory in systemd service
    applied bb291f53709c... Revert "nodejs: backport (partially) python 3.12 support"
    applied 1867ce60e2e8... faad2: Upgrade 2.10.0 -> 2.11.1
    applied 14c07e1b4529... layer.conf: add libbpf to NON_MULTILIB_RECIPES
    applied 10f1890af03d... c-ares: Upgrade 1.22.1 -> 1.24.0
    applied d44d4206b5bb... pkcs11-provider: Add recipe
    applied decf7095704a... qpdf: upgrade 11.6.3 -> 11.6.4
    applied 4bd31c491509... tk: Remove buildpath issue
    applied f795f9d40921... mdns: Upgrade 2200.40.37.0.1 -> 2200.60.25.0.4
    applied 668ba95ea7d1... php: remove lemon-native build dependency
    applied 0fbbc0b1cce4... c-ares: Move to tarballs, add ptest and static support
    applied 6a1d0752f8c8... python3-astroid: update to version 3.0.2
    applied 62d9c729df3e... python3-alembic: update to version 1.13.1
    applied 85139abedd78... python3-pymisp: update to verion 2.4.182
    applied e67a62b44c6e... python3-pydantic-core: add v2.14.5
    applied 0b1b5efeb521... python3-annotated-types: add v0.6.0
    applied 537a9e24c6d5... python3-pydantic: fix RDEPENDS
    applied e592a8ce9a3e... python3-dirty-equals: add v0.7.1
    applied 446124784bfd... python3-pydantic-core: enable ptest
    applied b48af247b814... python3-cloudpickle: add v3.0.0
    applied 1872badd7350... python3-pydantic: enable ptest
    applied 6ce73e925d47... nodejs: backport (partially) python 3.12 support
    applied d8637f07a281... python3-ninja: update to version 1.11.1.1
    applied fd35de7c55c5... python3-coverage: update to version 7.3.4
    applied 50e241df341c... python3-pdm: update to version 2.11.1
    applied aa8317720fe4... python3-paramiko: update to version 3.4.0
    applied ef76589e4b89... python3-zeroconf: update to version 0.131.0
    applied 34a49f38c57c... python3-wtforms: update to version 3.1.1
    applied 4531f0ff6d70... python3-isort: update to version 5.13.2
    applied cf59d70d6ae2... python3-protobuf: update to version 4.25.1
    applied edf5344106ca... python3-lazy-object-proxy: update to version 1.10.0
    applied 7b3b4532a265... python3-cantools: update to version 39.4.0
    applied c27646b41f2a... python3-sentry-sdk: update to version 1.39.1
    applied 8d34688fad9d... python3-xmlschema: update to version 2.5.1
    applied 01d5c8c626e2... python3-apiflask: update to version 2.1.0
    applied b7d5acb3523c... thin-provisioning-tools: Upgrade 1.0.4 -> 1.0.9
    applied c3ac5cf180f9... lemon: upgrade to 3.44.2
    applied fc035a8c4dc8... renderdoc: no need to depend on vim-native
    applied a50c63e2b7d7... python3-click-spinner: backport patch that fixes deprecated methods
    applied c331f59e42e9... networkmanager: fix some missing pkgconfig
    applied 85c7f15d1736... cpprest: upgrade 2.10.18 -> 2.10.19
    applied e1552304bf3c... avro-c: upgrade 1.11.2 -> 1.11.3
    applied b39c548100d8... python3-rapidjson: update to version 1.14
    applied 9723cc8de511... python3-bitarray: update to version 2.9.0
    applied b572db47ccaa... python3-pyfanotify: update to version 0.2.2
    applied 83f5f3d95b83... python3-eventlet: update to version 0.34.1
    applied 6fd6bd049c3e... python3-flask-wtf: update to version 1.2.1
    applied 33245220ad91... netdata: added Python as rdepends
    applied a21124a3209a... cyaml: new recipe
    applied 7596fc3d21e4... python3-grpcio: update to version 1.60.0
    applied 40b627c4a696... python3-grpcio-tools: update to version 1.60.0
    applied 5a55e4e480f1... python3-cmake: update to version 3.28.1
    applied 75f9fe8bab85... python3-flask-sqlalchemy: fix upstream uri check
    applied c600141d649c... python3-wtforms: fix upstream uri and version check
    applied 1a1deabbf0e4... gyp: update to the latest commit
    applied a9020fa41da1... python3-ipython-genutils: fix upstream uri and version check
    applied 075497ce2d71... python3-flask: fix upstream uri and version check
    applied a28ead865286... python3-wpa-supplicant: fix upstream uri and version check
    applied db2f5ee50b5e... python3-uswid: update to version 0.4.7
    applied a434b01e7b81... python3-flask-wtf: fix upstream uri and version check
    applied c89f9d0a833a... python3-gspread: update to version 5.12.3
    applied 0c17c667adf5... python3-pytest-html: update to version 4.1.1
    applied 3ddad1958930... python3-setuptools-scm-git-archive: remove obsolete package
    applied 2ebd36666a0d... python3-pyroute2: update to version 0.7.10
    applied 82153598816f... python3-constantly: update to version 23.10.4
    applied fbf6d4ee5321... python3-mypy: update to version 1.8.0
    applied 52891f17294e... python3-flask-jwt-extended: update to version 4.6.0
    applied 377c236a0451... python3-greenlet: update to version 3.0.3
    applied 10b479c2ce4c... python3-web3: update to version 6.13.0
    applied aff8b4d6e727... python3-parse: update to version 1.20.0
    applied 4929a3c44755... dool: upgrade 1.1.0 -> 1.3.1
    applied 1f2c2ebcbcf5... driverctl: upgrade 0.111 -> 0.115
    applied 02e20ddb169f... polkit: remove long obsolete 0.119 version
    applied 168be0b16459... mozjs-115: split the way-too-long PYTHONPATH line
    applied 993cf00efe1e... polkit: update mozjs dependency 102 -> 115
    applied b28b7135d7b8... mozjs-115: backport py 3.12 compatibility
    applied 599dfcfd6656... mozjs-102: remove the recipe
    applied e28f3d377736... gthumb: update 3.12.2 -> 3.12.4
    applied 9c68079a26b6... flatpak: do not rely on executables from the host
    applied 3f82f852009a... bolt: package systemd units
    applied ffd3a042d9c8... open-vm-tools: upgrade 12.1.5 -> 12.3.5
    applied aebb88b41f3c... hstr: upgrade 2.5.0 -> 3.1.0
    applied bf4d7f62840c... bearssl: Upgrade to latest
    applied b9b9a9578b48... libharu: upgrade 2.3.0 -> 2.4.4
    applied 0739cb15d513... dbus-cxx: upgrade 2.4.0 -> 2.5.0
    applied 327a0f0e613e... exiftool: upgrade 12.70 -> 12.71
    applied 5d050f078afc... uftp: upgrade 5.0.2 -> 5.0.3
    applied 51648324086a... ctags: upgrade 6.0.20231210.0 -> 6.0.20231224.0
    applied 85360acc4d93... jasper: Fix install conflict when enable multilib.
    applied bef4681e4188... jq: upgrade 1.7 -> 1.7.1
    applied dd093656b9cc... libmbim: upgrade 1.31.1 -> 1.31.2
    applied f690ea9e33d9... libqmi: upgrade 1.34.0 -> 1.35.1
    applied fb8f7ffddfcb... opencl-headers: upgrade 2023.04.17 -> 2023.12.14
    applied bd86be802a49... valijson: upgrade 1.0.1 -> 1.0.2
    applied 054e5ea2c2db... python3-apispec: upgrade 6.3.0 -> 6.3.1
    applied 47829c75bb56... python3-asyncinotify: upgrade 4.0.4 -> 4.0.5
    applied d9d42f84d73e... python3-bitarray: upgrade 2.9.0 -> 2.9.1
    applied 7ede8295ef50... python3-cassandra-driver: upgrade 3.28.0 -> 3.29.0
    applied 3225a285e91d... python3-ipython: upgrade 8.18.1 -> 8.19.0
    applied d9ace19a2135... python3-pydantic: upgrade 2.5.2 -> 2.5.3
    applied 57d796d63049... python3-regex: upgrade 2023.10.3 -> 2023.12.25
    applied 884dca3f269c... cjson: upgrade 1.7.16 -> 1.7.17
    applied 0fdda9232f61... opencl-icd-loader: upgrade 2023.04.17 -> 2023.12.14
    applied 8c2c816bc455... python3-distro: upgrade 1.8.0 -> 1.9.0
    applied c0de3223bed8... zchunk: upgrade 1.3.2 -> 1.4.0
    applied bcedf9f99ca6... postgresql: upgrade 15.4 -> 15.5
    applied 5b34766daadf... redis: upgrade 6.2.13 -> 6.2.14
    applied e31e02999c3a... python3-eventlet: upgrade 0.34.1 -> 0.34.2
    applied 4c8c1443776f... networkmanager: drop libnewt dependency
    applied f4c3c747d6df... samba: upgrade 4.18.8 -> 4.18.9
    applied 813fb0def8a8... i2cdev: New recipe with i2c tools
    applied f8d66f3174b0... python3-yappi: upgrade 1.4.0 -> 1.6.0; fix ptests
    applied 079cd908fcaa... driverctl: fix installed-vs-shipped
    applied 844635d0c20d... python3-kmod: add comment about update to version 0.9.2
    applied 4a1abfaa6d6c... python3-engineio: update to version 4.8.1
    applied 7b757a77d12d... python3-sqlalchemy: update to version 2.0.24
    applied 304034bec199... python3-pdm-backend: update to version 2.1.8
    applied 8fe935960010... python3-cantools: update to version 39.4.1
    applied ebea0db45087... python3-argh: update to version 0.30.5
    applied 2f4372ed707f... python3-dominate: update to version 2.9.1
    applied 639d7378ce5a... zfs: update to 2.2.2
    applied c6c636e3203f... Revert "libcamera: skip until upstream resolves python 3.12 compatibility"
    applied 7d8115d5507b... libcamera: Fix build with python 3.12
meta-security 070a1e82cc -> b2e1511338:
    applied 6cf4d653dcbc... libgssglue: update to 0.8
    applied 7ee7b8903d72... libhoth recipe update
    applied 699ffcbdaf17... python3-privacyidea: Update to 3.9.1
    applied a0731b7b3c26... lynis: Update SRC_URI to improve updater
    applied 0bc38b348b12... layers: Move READMEs to markdown format
    applied e67e3d377e7c... arpwatch: adjust CONFIGURE params to allow to build again.
    applied 3767ca82cf81... tpm2-tss: support native builds
    applied 57723ce65ebf... dm-verity-img.bbclass: use bc-native
    applied fd295b2c2821... dm-verity-img.bbclass: remove IMAGE_NAME_SUFFIX
    applied 73e03651ef78... dm-verity-img.bbclass: add DM_VERITY_DEPLOY_DIR
    applied b2e151133870... python3-pyinotify: fail2ban needs this module

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
