### PR TITLE
subtree update: 2f1f94c462 -> 2f54c4c1fa

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,19 +2,19 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 4d22f982bce8dff6f8c4d11845c47a4d39f961c6
+last_revision = 57124220111285bc6e731985f46da16bb1d20339
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 7d8115d5507bac6c018fbff8a7aa9bc513c2bc46
+last_revision = 098dc606f967b8284911f1a6a89ccc83fb223964
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 4c033eb07442959ed76d769fd2b4649612327155
+last_revision = b859bc3eca344a585e19390018e97bfba5a74c10
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -26,5 +26,5 @@ last_revision = b2e1511338705f90f34f19f938650c185200c067
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 4675bbb757a4755e80914afb6840a640f292fc08
+last_revision = 61182659c212db24e52cdbcdbb043c7b0de86094
 


### PR DESCRIPTION
meta-openembedded 7d8115d550 -> 098dc606f9:
    applied 1cc4b9a1d6e5... c-ares: Filter out "Live" tests
    applied 30b37bb09ee5... ptest-packagelists-meta-oe.inc Add c-ares to PTESTS_SLOW_META_OE
    applied b46ee0ca65fb... fontforge: add a readline PACKAGECONFIG
    applied 3cca2ec51467... volume-key: disable python bindings
    applied 369659d17e14... audit: disable python bindings as incompatible with python 3.12
    applied 3dd8878b320d... cmpi-bindings: update 1.0.1 -> 1.0.4
    applied aa031c8685a6... libpwquality: backport a python 3.12 compatibility patch
    applied 2724acc91f9f... mycroft: do not depend on python3-xmlrunner
    applied 0ece1e8334a8... python3-xmlrunner: remove the recipe
    applied 76e0113299bb... system-config-printer: rely on setuptools to obtain distutils copy
    applied 40539d3d4085... python3-gmpy2: fix python 3.12 issues
    applied b118d9adfed5... python3-custom-inherit: fix python 3.12 builds
    applied 70b13461fe24... python3-jsonrpcserver: remove
    applied e2da07a13e3c... python3-oslash: remove
    applied 51e070301e86... nmap: disable ndiff
    applied 69490517db12... wireshark: update 4.0.10 -> 4.2.0
    applied 03dd014eb029... openipmi: update 2.0.32 -> 2.0.34
    applied 38cf12e8c3af... libsigrokdecode: add python 3.12 support
    applied 628a8d011f79... cockpit: add setuptools dependency to bring in distutils copy
    applied ef1b5de04c66... mongodb: skip until python 3.12 fixes are available.
    applied 211ec629fe38... mercurial: ensure setuptools is present as distutils is no longer (mercurial tries both)
    applied 864a639148df... rwmem: fix python modules packaging
    applied 2e3c18f2d34b... upm: get disutils copy via setuptools
    applied e594e1c2926d... python3-kmod: remove the recipe
    applied 26385a54b095... hplip: provide setuptools for the distutils copy
    applied 107614cd20a2... mraa: Update to latest tip of trunk
    applied e1c4be9bd47c... vsomeip: upgrade 3.3.8 -> 3.4.10
    applied 7a6ca59ab1f5... libnvme: upgrade 1.6 -> 1.7.1
    applied cb6cd5a566d6... audit: reenable python bindings and bring in distutils via setuptools (needed with python 3.12)
    applied a871d5edc43c... cglm: upgrade 0.9.1 -> 0.9.2
    applied bcf04e4948c0... ctags: upgrade 6.0.20231224.0 -> 6.1.20231231.0
    applied ff674dc99211... exiftool: upgrade 12.71 -> 12.72
    applied 23c397a7f40f... feh: upgrade 3.10.1 -> 3.10.2
    applied 1bea2e8c3053... libssh: upgrade 0.10.5 -> 0.10.6
    applied 0fae40f44c1d... squid: upgrade 6.5 -> 6.6
    applied 2667ce85d0a6... imapfilter: upgrade 2.8.1 -> 2.8.2
    applied e53bbbed774f... redis-plus-plus: upgrade 1.3.10 -> 1.3.11
    applied 36f7320193be... python3-netaddr: upgrade 0.9.0 -> 0.10.0
    applied a4f5de220148... plocate: upgrade 1.1.19 -> 1.1.20
    applied a10314fdd0a7... python3-cantools: upgrade 39.4.1 -> 39.4.2
    applied e17de9ffb93b... python3-coverage: upgrade 7.3.4 -> 7.4.0
    applied a50b58f6268d... python3-flask: upgrade 2.3.3 -> 3.0.0
    applied 31fad7ab5eae... python3-gspread: upgrade 5.12.3 -> 5.12.4
    applied fbff72263d73... python3-pydot: upgrade 1.4.2 -> 2.0.0
    applied 5473dfef55b4... qpdf: upgrade 11.6.4 -> 11.7.0
    applied e38540eaeb9e... thingsboard-gateway: upgrade 3.4.3.1 -> 3.4.4
    applied 9ef06c6319d2... v4l-utils: Add PACKAGECONFIG for v4l2-tracer to fix determinstic build
    applied 0f4a2e7606e5... libpaper: upgrade 2.1.0 -> 2.1.2
    applied 3f166bfbb791... i2cdev_git: Remove AUTHOR field
    applied efa0a0af252a... collectd: Remove rrdtool from DEPENDS
    applied 231c8bd2642c... keepalived: Move the sample configuration files to a separate package
    applied 13a1b1b1a56b... ssd1306_git.bb: Add ssd1306_linux
    applied 7b66ea10817f... srecord: fix install prefix
    applied 45672db184f3... python3-pydantic-core: upgrade 2.14.5 -> 2.14.6
    applied 5231104a0a65... protobuf-c: upgrade 1.4.1 -> 1.5.0
    applied b56ab3d10999... python3-pytest-cov: add missing python3-coverage dependency
    applied 34a20e8b8aab... krb5: use PACKAGE_BEFORE_PN
    applied 8838fb392808... picocom: Update to 2023-04
    applied 65116b253bf4... usleep: Make the version consistent
    applied a7bbf879b5a0... onig: upgrade 6.9.8 -> 6.9.9
    applied b1a7262087a8... libcppkafka: Update to tip of trunk
    applied 9c91e6018dc3... clinfo: upgrade 3.0.21.02.21 -> 3.0.23.01.25
    applied 8b100a34f640... python3-h5py: backport a cython 3.x compatibility patch
    applied da68f807bd71... opensc: upgrade 0.23.0 -> 0.24.0
    applied 1a05731de484... luajit: upgrade 2.1beta -> 2.1
    applied 34794c0c28eb... python3-pydantic-core: Rename the cpython module on musl
    applied de8b61ef0e21... gnome-terminal: fix search_provider build
    applied 695bdeebb0cd... pcsc-lite: upgrade 2.0.0 -> 2.0.1
    applied 430df76f8d50... libtinyxml2: upgrade 9.0.0 -> 10.0.0
    applied f38b0faa6b9d... libtinyxml2: Package needed resources to run ptests
    applied b2ba89eb8912... libtdb: upgrade 1.4.8 -> 1.4.9
    applied cf1dd83b6fbb... libtalloc: upgrade 2.4.0 -> 2.4.1
    applied 03e1353cb72c... libtevent: upgrade 0.14.1 -> 0.16.0
    applied 5905144554d8... libldb: upgrade 2.7.2 -> 2.8.0
    applied 5260f11b04a3... samba: upgrade 4.18.9 -> 4.19.3
    applied 628084d6b042... python3-pylint: Ignore failing ptests
    applied 73c35829b469... libplist: make sure rm doesn't fail on nonexistent file
    applied 1e848281ef6f... layer.conf: Add libdevmapper-native PREFERRED_RPROVIDER
    applied 6aab924b38f2... ssd1306: Update and remove patch
    applied 565f8cdbad31... adw-gtk3: upgrade 5.1 -> 5.2
    applied 922b99f8c801... dialog: upgrade 1.3-20231002 -> 1.3-20240101
    applied 983eb6a25799... ghex: upgrade 45.0 -> 45.1
    applied d61318c0085b... jwt-cpp: upgrade 0.6.0 -> 0.7.0
    applied 007f48574435... libcloudproviders: upgrade 0.3.4 -> 0.3.5
    applied ec5631c9bda0... libgedit-gtksourceview: upgrade 299.0.4 -> 299.0.5
    applied 557ab1259118... libjcat: upgrade 0.1.14 -> 0.2.0
    applied 204e694ac275... libraw: upgrade 0.21.1 -> 0.21.2
    applied 3f88224fb9c4... libsass: upgrade 3.6.5 -> 3.6.6
    applied d3582fcffcd5... chrony: upgrade 4.4 -> 4.5
    applied 1cccaa50579c... tgt: upgrade 1.0.83 -> 1.0.90
    applied c5b886b307d7... lapack: upgrade 3.10.1 -> 3.12.0
    applied f4711b879df1... libio-pty-perl: upgrade 1.17 -> 1.20
    applied 466370a08753... webkitgtk3: upgrade 2.42.3 -> 2.42.4
    applied 94d2364152a8... xmlsec1: upgrade 1.3.2 -> 1.3.3
    applied a91572be2828... python3-argh: upgrade 0.30.5 -> 0.31.0
    applied ebd44706dddc... python3-cvxopt: upgrade 1.2.7 -> 1.3.2
    applied 1957e73efbb1... python3-sqlalchemy: upgrade 2.0.24 -> 2.0.25
    applied 41349043efed... python3-aiohttp-jinja2: upgrade 1.5.1 -> 1.6
    applied 3f81f9471a02... python3-bitarray: upgrade 2.9.1 -> 2.9.2
    applied ebaa41bafc99... python3-google-api-python-client: upgrade 2.111.0 -> 2.112.0
    applied ed772f2b8073... python3-google-auth: upgrade 2.25.2 -> 2.26.1
    applied e939b52573e3... python3-lz4: upgrade 4.3.2 -> 4.3.3
    applied 5e21f78729d1... python3-pdm: upgrade 2.11.1 -> 2.11.2
    applied a53436cc95c2... python3-pyflakes: upgrade 3.1.0 -> 3.2.0
    applied 0c2801196d3f... python3-pymisp: upgrade 2.4.182 -> 2.4.183
    applied a7177c725367... python3-pytest-asyncio: upgrade 0.23.2 -> 0.23.3
    applied d2552ce8162b... python3-traitlets: upgrade 5.14.0 -> 5.14.1
    applied 51a4bc0ffe16... traceroute: upgrade 2.1.3 -> 2.1.5
    applied d1d3cf63e0c1... wolfssl: upgrade 5.6.4 -> 5.6.6
    applied 85d582c046d4... xerces-c: upgrade 3.2.4 -> 3.2.5
    applied e54294de384c... zenity: upgrade 4.0.0 -> 4.0.1
    applied 29cb1495b0be... pcsc-tools: upgrade 1.6.2 -> 1.7.1
    applied 9a8839e2b715... imagemagick: upgrade 7.1.1-8 -> 7.1.1.26
    applied 15abedd8ab5a... libconfig-general-perl: Enable on musl targets
    applied 4caa10faa85c... tgt: Fix build with musl
    applied 250cc196992a... python3-webargs: Upgrade 8.3.0 -> 8.4.0
    applied 1192917fbfd3... python3-wtforms: Upgrade 3.1.1 -> 3.1.2
    applied 57f8d6e1dfea... python3-kivy: Upgrade 2.2.1 -> 2.3.0
    applied 03cfdf3d077b... wavpack: upgrade 5.1.0 -> 5.6.0
    applied 7c4f3f1e3eea... nvme-cli: upgrade 2.6 -> 2.7.1
    applied 11056735e8c2... daq: Fix install conflict when enable multilib.
    applied df2e4cff8e90... ipmitool: Make the version consistent
    applied 4ee1b39643f1... mdio-tools: upgrade 1.3.0 -> 1.3.1
    applied 348792f025c3... mutter: update 45.1 -> 45.3
    applied 46ce0a49aa72... gnome-shell: update 45.1 -> 45.3
    applied bff345308053... gnome-control-center: update 45.1 -> 45.2
    applied 65b0dca5ea2a... gnome-software: update 45.1 -> 45.3
    applied 09b354f3cc56... gnome-shell-extensions: update 45.1 -> 45.2
    applied d3fb6ea06e4f... kernel-selftest: remove Wno-alloc-size-larger-than from scripts/Makefile.extrawarn
    applied 9d0d7d9d621b... nginx: fix CVE-2023-44487
    applied 6fd9eacd7b02... grpc: upgrade 1.59.2 -> 1.60.0
    applied 098dc606f967... libpwquality: respect PYTHONSITEDIR
meta-arm 4d22f982bc -> 5712422011:
    applied ad9eadb70e7e... arm-bsp/linux-yocto: add linux-yocto 6.5 temporarily
    applied 01e60aa0e3fd... arm-bsp/trusted-firmware-m: update libmetal and open-amp to a release
    applied 2cc6f05f3e09... arm-bsp/trusted-firmware-m: update libmetal and open-amp to 2023.04.0
    applied 6de882ae93da... arm: modify patches to have email headers and correct date fields
    applied 450e42e7c243... arm-bsp/linux-yocto: corstone1000: bump to v6.6%
    applied 0d71ca11c615... arm-bsp/optee-os: remove unused 3.18 files
    applied bcabc921f6c3... arm/optee-os: use sysroot in CFLAGS
    applied 2f9112a8fd9c... arm/optee-os: remove unneeded clang patches
    applied 98cf1495dbca... arm/scp-firmware: update git repository to new location
    applied 571242201112... arm-bsp/u-boot: rebase patches for v2024.01
meta-raspberrypi 4c033eb074 -> b859bc3eca:
    applied b859bc3eca34... bcm2835: update 1.71 -> 1.73
poky 4675bbb757 -> 61182659c2:
    applied 6e62ccffb654... speexdsp: enable native variant
    applied 8c732425edf7... openssh: Add PACKAGECONFIG option to customize sshd mode
    applied b221ae6cde53... gawk: upgrade from 5.2.2 to 5.3.0
    applied 8ea90fd10304... systemd-bootchart: upgrade from 234 to 235
    applied 0c7eca932f27... ffmpeg: upgrade 6.1 -> 6.1.1
    applied fc0402dbd7b8... meson: upgrade 1.3.0 -> 1.3.1
    applied a062b7727d4c... ccache: upgrade 4.8.3 -> 4.9
    applied 7978fd547e63... mesa: upgrade 23.3.1 -> 23.3.2
    applied 4989adbebb88... subversion: upgrade 1.14.2 -> 1.14.3
    applied 76f693eb2516... python3-dbusmock: upgrade 0.30.1 -> 0.30.2
    applied 67c02597c157... python3-hatch-fancy-pypi-readme: upgrade 23.1.0 -> 24.1.0
    applied 1c3fe080178e... python3-hypothesis: upgrade 6.92.1 -> 6.92.2
    applied 84cd0f273199... python3-pycryptodome: upgrade 3.19.0 -> 3.19.1
    applied 4464aebcfc52... python3-pycryptodomex: upgrade 3.19.0 -> 3.19.1
    applied 0638e664c06f... python3-pytest: upgrade 7.4.3 -> 7.4.4
    applied 992d59564b84... connman: Fix build with musl
    applied f99f55259dc7... rpm: Fix build with musl
    applied d1792b9ad33b... libcap-ng: upgrade 0.8.3 -> 0.8.4
    applied 3fc6170fe402... libcap-ng-python: upgrade 0.8.3 -> 0.8.4
    applied ffefbfb66ba3... dbus-wait: bump srcrev
    applied 468633036c4b... sudo: upgrade from 1.9.15p2 to 1.9.15p5
    applied f76ddac2f7a8... python3-attrs: upgrade 22.1.0 -> 23.2.0
    applied ee274a9d085d... python3-lxml: upgrade 4.9.4 -> 45.0.0
    applied 64d5db2f89b4... devtool: modify: fix exception
    applied a703d8ddef64... oeqa systemd.py: settle() using "running" or "degraded" state
    applied 6d4fb81e8085... gawk: Add coreutils to rdeps for ptests package
    applied 74c234bf0db6... bitbake: toaster/tests: Bug-fix on TestProjectConfigTab::test_image_recipe_show_rows
    applied 1cd56989a08d... bitbake: toaster/tests: Bug-fix element click intercepted
    applied 070aa227057e... bitbake: toaster/tests: Delay driver first action on create new project page
    applied cf7152a4cb4c... util-linux/util-linux-libuuid: ugprade from 2.39.2 to 2.39.3
    applied 20278437b071... elfutils: Update license information
    applied 64a737df5f77... python3-bcrypt: upgrade 4.1.1 -> 4.1.2
    applied d04ed37fa749... python3-attrs: enable ptest
    applied f01ea3700e1e... devtool/standard: correctly escape \
    applied 14220bb99c2b... libusb1: Do not match on -rc versions
    applied 04f1d1ec6bd7... usbutils: Update to version 017
    applied 0d93308425fd... qemu.bbclass: fix a python TypeError
    applied 49ccf2f5e01c... bitbake: toaster/tests: Setup delay after driver action self.get(url)
    applied c0ade693af36... bitbake: toaster/tests: bug-fix "#hint-error-project-name" should be visible
    applied 0dcf84f83031... bitbake: toaster/tests: Bug-fix "element not interactable" in TestLayerDetailsPage::test_edit_layerdetails
    applied 36dc42bde7d9... bitbake: toaster/tests: Bug-fix ToasterTable show_rows testcases
    applied 3f415929200c... bitbake: bitbake: event: Inject empty lines to make code match lineno in filename
    applied 4e2fcdb38338... bitbake: bitbake: tests/event: Add test_lineno_in_eventhandler
    applied 4890c6a7ca81... bitbake: fetch/checkstatus(): do not print the URI twice in FetchError exception
    applied 56b1af37dc61... bitbake: fetch/wget/checkstatus(): include the URL in debugging output about status check failure
    applied c665a2c93337... bitbake: ast: Fix EXPORT_FUNCTIONS bug
    applied bc22d82c2f0c... bitbake: server/process: catch and expand multiprocessing connection exceptions
    applied 98c5c96dd390... bitbake: ui/knotty: properly handle exceptions when calling runCommand()
    applied 67e3f2433391... bitbake: bitbake/runqueue: rework 'bitbake -S printdiff' logic
    applied 67be7cf82ba2... selftest/sstatetests: fix up printdiff test to match rework of printdiff logic
    applied 7b3668a0aa8f... selftest/sstatetest: re-enable gcc printdiff test
    applied 1a2708509216... python3-pyyaml: make compatible with cython 3.x
    applied 5e1bc611d625... python3-cython: update 0.29.36 -> 3.0.7
    applied 7fae6f3500b6... gptfdisk: Make the version consistent
    applied fe702844b313... taglib: fix upstream version check
    applied 9d0db4892586... libpcre2: fix upstream version check
    applied 90ca84dbf927... icon-naming-utils: take tarball from debian
    applied 46262ee83edd... selftest/sstatetests: include fetcher diagnostics into CDN test failure message
    applied 40d0aff1c2fa... u-boot: Upgrade to 2024.01
    applied 56c7ea02d29d... systemd: add udev-bash-completion package
    applied 91694dfce75f... syslinux: Allow mtools to be optional
    applied cf1311917995... rng-tools: remove obsolete build time dependency on sysfsutils
    applied a3299e18a72b... linux-firmware: Fix the linux-firmware-bcm4373 FILES variable
    applied 17404d96e73b... kmscube: Change header file to <GLES3/gl3.h>
    applied 41eb4934cf8a... kmscube: Add package version
    applied b11e3aa995f8... rootfs.py: check depmodwrapper execution result
    applied 120ac9aa8bf2... contributor-guide: use "apt" instead of "aptitude"
    applied 5841968223e1... ref-manual: update tested and supported distros
    applied 040eea3de69f... dev-manual: start.rst: update use of Download page
    applied b5b64bd0e3a1... ref-manual: classes: remove insserv bbclass
    applied 0b449adebe82... dev-manual: update license manifest path
    applied f72759de573c... ref-manual: document cmake-qemu class
    applied ed6c38e3aff1... manuals: document VSCode extension
    applied b0f2fd0fade5... documentation: Add UBOOT_BINARY, extend UBOOT_CONFIG
    applied 0971cf620c86... migration-guide: add release notes for 4.3.2
    applied e7ce961d369c... glib-2.0: no need to depend on target gtk-doc
    applied 3c72b2d7118c... autotools: append to EXTRA_AUTORECONF
    applied 3dc895804f17... autotools: don't exclude gtkdocize
    applied 1cf26ed78b35... gtk-doc: fix DEPENDS
    applied 614b228d0ac7... gtk-doc: remove obsolete logic
    applied 97ef820a607f... gtk-doc: don't use docdir set in environment in gtkdocize
    applied 2c8e3a3b8374... gtk-doc: don't manually call gtkdocize
    applied c8c1c1e4e0e1... kmod: fix configure with autopoint calling gtkdocize
    applied 79431f5ae35e... util-linux: enable gtk-doc
    applied f71b260094fd... tcl: Fix prepending to run-ptest script
    applied 912dd772859e... coreutils: Ignore line-bytes.sh and no-allocate tests on musl
    applied f315b0975868... selftest/SStatePrintdiff: ensure all base signatures are present in sstate in test_image_minimal_vs_base_do_configure
    applied 351737169a4b... opkg-utils: Backport fix to drop --numeric-owner parameter
    applied ac6fb1aa6a52... meson: use pkg-config in the cross files
    applied ef9f8330c1b8... cairo: upgrade to 1.18.0
    applied 1863c0da9349... glibc: Set status for CVE-2023-5156 & CVE-2023-0687
    applied 405cc80b6b1b... shadow: update 4.13 -> 4.14.2
    applied ea9e07a3e25a... shadow: link executables statically for -native variant
    applied dda251dfc2dc... xmlcatalog: limit to native recipes only
    applied 61182659c212... bitbake: runqueue: Fix runall all bug

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
