### PR TITLE
subtree update: 936c0f5c9f -> b981c570be

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,13 +2,13 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 57124220111285bc6e731985f46da16bb1d20339
+last_revision = 1cad3c3813cc52c89010c081b70a28c1e0981e74
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 098dc606f967b8284911f1a6a89ccc83fb223964
+last_revision = 4dbbef7a39ad18206ca6cebf7a1e08aebe5b5a65
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
@@ -26,5 +26,5 @@ last_revision = b2e1511338705f90f34f19f938650c185200c067
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 61182659c212db24e52cdbcdbb043c7b0de86094
+last_revision = 7af374c90c349af2c7ae9cf7d4fa14eeeb23b108
 

--- a/master.conf
+++ b/master.conf
@@ -2,19 +2,19 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 1cad3c3813cc52c89010c081b70a28c1e0981e74
+last_revision = 6bb1fc8d8c815768effe7a19094ecb7e6c1258cb
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 4dbbef7a39ad18206ca6cebf7a1e08aebe5b5a65
+last_revision = 9953ca1ac0bf5747aaa664d25a6c06f7f0ad2446
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = b859bc3eca344a585e19390018e97bfba5a74c10
+last_revision = 9c901bf170960069576b9323f69d43a8b6c4bd71
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -26,5 +26,5 @@ last_revision = b2e1511338705f90f34f19f938650c185200c067
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 7af374c90c349af2c7ae9cf7d4fa14eeeb23b108
+last_revision = 348d9aba3305cd98b0c0b1ec0f4b1407e786307a
 


### PR DESCRIPTION
meta-arm 5712422011 -> 1cad3c3813:
    applied 83df70e18179... arm-bsp/documentation: upgrade Sphinx slightly
    applied 8127e49f6bdb... arm/pyhsslms: update to 2.0.0
    applied c538ae49eea6... arm/trusted-firmware-m: update to 2.0.0
    applied 3d3cf56dc99e... arm/fvp-base-a-aem: upgrade to 11.24.11
    applied 4ada4852830c... arm/opencsd: update to 1.4.2
    applied 1c21b457dbd0... arm-bsp/n1sdp: Downgrade to 6.1 linux yocto kernel
    applied 1cad3c3813cc... arm-bsp/linux-yocto: Remove EOL Linux yocto kernel 6.5
meta-openembedded 098dc606f9 -> 4dbbef7a39:
    applied 4ea46a31b951... frr: use update-alternatives for ietf-interfaces.yang
    applied 8fce02300e34... libsmi: use update-alternatives for ietf-interfaces.yang
    applied 9389d63fdddc... v4l-utils: Update to 1.26.1
    applied 3449642b5806... frr: Fix install conflict when enable multilib.
    applied b5343d2f3829... thin-provisioning-tools: Drop musl fixes (fixed upstream)
    applied 205b44eb45cc... libuser: fix gtk-doc configure call
    applied 7b7d0e38ff2e... libuser: remove obsolete GTKDOC_DOCDIR assignment
    applied cbc22b5ba4c9... gtksourceview4: remove check for target gtk-doc
    applied f01a5bf834dc... gtksourceview4: remove obsolete workaround for build failures
    applied 072dd00d971e... i2cdev: Fix MUSL build
    applied f8492c7a283d... flatpak: fix gtk-doc build
    applied e6b70ce30a19... telepathy-glib: inherit gtk-doc
    applied a48cd50ad7d3... glade: inherit gtk-doc, fix FILES
    applied 202e00326277... libgxim: inherit gtk-doc
    applied 4f14322e782f... gmime: inherit gtk-doc
    applied a76dab81746c... raptor2: inherit gtk-doc
    applied 1116ce173337... python3-web3: update to version 6.14.0
    applied dde3f14af85b... python3-engineio: update to version 4.8.2
    applied b58a7679c0a7... python3-marshmallow: update to version 3.20.2
    applied 72c56daa6348... python3-apispec: update to version 6.4.0
    applied 243fafa0920d... python3-protobuf: update to version 4.25.1
    applied 4b9cd22f4752... python3-eth-hash: update to version 0.6.0
    applied 73452860de65... python3-google-auth: update to version 2.26.2
    applied ccd8dea4427a... python3-socketio: update to version 5.11.0
    applied 5e91f4494005... python3-google-api-python-client: update to version 2.113.0
    applied ac49a0988710... gvfs: drop gnome-keyring rdepend
    applied c74cdd43f37f... adcli: use https protocol for fetching
    applied 5e8a4a6dd022... grpc: correct dependencies
    applied ca43c0abd1db... thunar: inherit gtk-doc
    applied 53e68a189a7d... libxklavier: inherit gtk-doc
    applied 74745dcd0167... libwnck: inherit gtk-doc
    applied 825c28133b52... schroedinger: inherit gtk-doc
    applied 259b9fd719d8... gst-shark: inherit gtk-doc
    applied c076a263517e... rng-tools: move from oe-core to meta-oe
    applied 1647e20b2edd... evolution-data-server: Use inherit_defer for native class
    applied 4dbbef7a39ad... opencl-icd: Rename rdepends to virtual-opencl-icd
poky 61182659c2 -> 7af374c90c:
    applied e5a9f41366c3... iw: upgrade 5.19 -> 6.7
    applied d2b445384da3... rng-tools: move to meta-oe
    applied ea5cea668fb7... init-ifupdown: add predictable interface names
    applied d764029c45c9... linux-firmware: upgrade 20231030 -> 20231211
    applied 696b71cc95e5... linux-firmware: package PowerVR firmware
    applied f7c094fce0b4... mesa: Upgrade 23.3.2 -> 23.3.3
    applied fbbcf19f61fc... bmaptool: add 3 fixes
    applied ad3eb83b56fd... insane.bbclass: Check for adjtime in check_32_bit_symbols
    applied fc2d534e38a7... insane.bbclass: Python code cleanup in check_32bit_symbols
    applied 5031cf42ffb2... package.py: fix Darwin support
    applied 3db106c41b22... chrpath.bbclass: fix Darwin support
    applied 90ea98a24c3d... siteinfo.bbclass: add support for darwin19 and darwin21
    applied 4564d8f3762f... webkitgtk: Workaround for clang compiler segfault
    applied 89755de94d4a... mdadm: Disable 10ddf-fail-spare and 10ddf-fail-stop-readd testcases
    applied f7c4d1180444... linux-firmware: split out rockchip/dptx firmware
    applied 663f1805742f... libdrm: Upgrade to 2.4.120
    applied c56fce9e5621... bitbake: ast/BBHandler: Add inherit_defer support
    applied 55eaa3eb3f87... allarch: Fix allarch corner case
    applied 12619deabd1f... rootfs: Fix MULTILIB_RE_ALLOW to be inherit order independent
    applied bc883e49912b... rootfs-postcommands: Try and improve ordering constraints
    applied c917323a39da... classes/recipes: Switch to use inherit_defer
    applied c8783797affa... libtool: Update patches to mark as backports
    applied 3742a45c0ecd... libtool: Update nios2 patch to match upstream merged version
    applied 776b1aab1255... libtool: Update prefixmap and clang patches to match upstream submission
    applied 907150679d0e... libtool: Update cleanup sysroot handling patch
    applied 8ab08022f6d1... libtool: Update patch offsets
    applied a193a3f1e099... libtool: Update further patch status to backport
    applied 4ca2c2919e5a... iputils: update to 20240117
    applied 75b340c29c5a... musl: doesn't support riscv32
    applied e85f0c247fa2... libunwind: merge .inc and .bb
    applied cb02c049f489... libunwind: refresh patches
    applied eca21ccbc53d... libunwind: clean up configuration
    applied 6e00774a79b3... classes-global/insane: Add check for "virtual/" in RPROVIDES and RDEPENDS
    applied 376a8a1f3add... python3-alabaster: upgrade 0.7.13 -> 0.7.16
    applied 0161d08ac93a... recipetool: Don't fail on local go modules
    applied d5e2279d2141... classes: go-vendor: Reference local modules
    applied 3e579c303ee0... classes: go-vendor: Handle modules from the same repo
    applied 4eca05e15bee... classes: go-vendor: Unlink vendor dir later
    applied 0576bd1edd85... recipetool: Proceed even with a missing license file
    applied 5eb10c53d88c... recipetool: Disregard version in URL for replaced modules
    applied b6766e0ac2a6... oeqa/selftest/recipetool: Move create_go test to a proper class
    applied a075bf502eed... oeqa/selftest/recipetool: Move helper function to the class scope
    applied 58722df9e1a9... oeqa/selftest/recipetool: Add test coverage for local go modules
    applied f09d4637588c... glib-2.0: ensure GI_DATA_ENABLED is set
    applied 375ac472d848... gobject-introspection-data.bbclass: move do_compile() tweak to g-i class
    applied 78e30d940d1a... python: update 3.11.5 -> 3.12.1
    applied 2ebe7f60fd47... reproducible: Fix race with externalsrc/devtool over lockfile
    applied 09b69a69f57c... rng-tools: Revert "rng-tools: move to meta-oe"
    applied 101580d72fb6... openssl: Fix build on riscv
    applied d2c39554e575... xserver-xorg: 21.1.9 -> 21.1.11
    applied 5af6b05e2e57... mpg123: upgrade 1.32.3 -> 1.32.4
    applied 77bc0181ae61... bind: upgrade 9.18.20 -> 9.18.21
    applied b9fee5ff9e53... iproute2: upgrade 6.6.0 -> 6.7.0
    applied 23311babb0dc... kexec-tools: upgrade 2.0.27 -> 2.0.28
    applied 2a5b8a9d538e... libbsd: upgrade 0.11.7 -> 0.11.8
    applied 712448ca8e61... libxmlb: upgrade 0.3.14 -> 0.3.15
    applied 8a90940ada00... nghttp2: upgrade 1.57.0 -> 1.58.0
    applied e100286f5359... ofono: upgrade 2.2 -> 2.3
    applied b682671cfb38... python3-numpy: upgrade 1.26.2 -> 1.26.3
    applied 8a614d5e4531... vte: upgrade 0.74.1 -> 0.74.2
    applied 6d76e1bd3317... python3-cython: upgrade 3.0.7 -> 3.0.8
    applied b8d1f922a881... python3-git: upgrade 3.1.40 -> 3.1.41
    applied 25787e744917... python3-hypothesis: upgrade 6.92.2 -> 6.92.9
    applied 46c3f92c807c... python3-jinja2: upgrade 3.1.2 -> 3.1.3
    applied e92131d37189... python3-markdown: upgrade 3.5 -> 3.5.2
    applied 687304d7311f... python3-more-itertools: upgrade 10.1.0 -> 10.2.0
    applied 28ccef7f44b9... python3-pycryptodome: upgrade 3.19.1 -> 3.20.0
    applied 264ea5358147... python3-pycryptodomex: upgrade 3.19.1 -> 3.20.0
    applied e821ae4fae5e... python3-trove-classifiers: upgrade 2023.11.29 -> 2024.1.8
    applied f5a59ab3169b... stress-ng: upgrade 0.17.03 -> 0.17.04
    applied 11f0910a3e0a... virglrenderer: upgrade 1.0.0 -> 1.0.1
    applied cf69c6843fb6... xz: upgrade 5.4.4 -> 5.4.5
    applied 7af374c90c34... build-appliance-image: Update to master head revision

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
