### PR TITLE
subtree update: f575142f1a -> dcb7fbb282

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 6bb1fc8d8c815768effe7a19094ecb7e6c1258cb
+last_revision = 025f76a14f6c9474cc273b17033430d47ad12606
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 9953ca1ac0bf5747aaa664d25a6c06f7f0ad2446
+last_revision = 528f273006965496ce7e19147f0a0e34a97a8f9c
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 9c901bf170960069576b9323f69d43a8b6c4bd71
+last_revision = dbf1113a8277772ddb59fb1c44013e4f3c6d2dda
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = b2e1511338705f90f34f19f938650c185200c067
+last_revision = 30e755c59204cbd64c3aa12e64ab33041f6f02c0
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 348d9aba3305cd98b0c0b1ec0f4b1407e786307a
+last_revision = fc8e5d7c13f62e987b76971116cf290fd01a0c8f
 


### PR DESCRIPTION
poky 348d9aba33 -> fc8e5d7c13:
    applied fd0980f74f0b... python3-numpy: Use Large File Support version of fallocate
    applied ed0818060868... sysroot user management postinsts: run with /bin/sh -e to report errors when they happen
    applied 55bfa994518a... classes/multilib: expand PACKAGE_WRITE_DEPS in addition to DEPENDS
    applied d00682ab5c2d... classes/staging: capture output of sysroot postinsts into logs
    applied 347abb8c06b6... classes/package_rpm: write file permissions and ownership explicitly into .spec
    applied 2b20d612b4b6... classes/package_rpm: use weak user/group dependencies
    applied 683c839c4576... classes/package_rpm: set bogus locations for passwd/group files
    applied 482ed7cd8035... oeqa/runtime/rpm: fail tests if test rpm file cannot be found
    applied 05d0b9eafb85... rpm: update 4.18.1 -> 4.19.1
    applied 82eb0c47e487... gtk4: update 4.12.4 -> 4.12.5
    applied 4cb6ff8a57cb... xz: Add ptest support
    applied bcbb15563503... elfutils: Fix build with gcc trunk
    applied c4a9b044d85a... lttng-modules: upgrade 2.13.10 -> 2.13.11
    applied cda5907dafea... python3: Initialize struct termios before calling tcgetattr()
    applied 2ced056c510b... piglit: Update to latest revision
    applied 0f61386628df... qemu: Replace the basename patch with backport
    applied 5573fb12ebc1... oeqa/qemurunner: Handle rare shutdown race
    applied f80f232fbd3c... qemu: fix target build with ccache enabled
    applied dddc7cf04147... python3-yamllint: add missing dependency
    applied db87a18a92b6... xwayland: Upgrade 23.2.3 -> 23.2.4
    applied d50c4a1e362d... gnutls: Upgrade 3.8.2 -> 3.8.3
    applied afe4c413f7a4... cmake.bbclass: use --install
    applied c9c0974209d3... devtool: support plugins with plugins
    applied c17ce99a2fd6... devtool: refactor exec_fakeroot
    applied 50618e59ddf6... devtool: refactor deploy to use exec_fakeroot_no_d
    applied c2813a4c69bf... devtool: refactor deploy-target
    applied 2608d399a2d5... go: update 1.20.12 -> 1.20.13
    applied 069d2dfd86e8... qemu: Allow native and nativesdk versions on Linux older then 4.17
    applied 04eac1f2b67e... armv8/armv9: Avoid using -march when -mcpu is chosen
    applied 3bb286730b33... initscripts: Add custom mount args for /var/lib
    applied 05f4e7a459de... mesa: Upgrade 23.3.3 -> 23.3.4
    applied f00f7e1570fb... dropbear: remove unnecessary line
    applied 43f9098a6959... grub2: ignore CVE-2023-4001, this is Red Hat-specific
    applied 4584746c1aca... classes/package_rpm: correctly escape percent characters
    applied e5604d346c6b... openssl: backport fix for CVE-2023-6129
    applied cc24a0ff76f2... opensbi: append LDFLAGS to TARGET_CC_ARCH
    applied ab37ae5bdd46... u-boot: add missing dependency on pyelftools-native
    applied 1bd73eddb5e1... setftest/cdn tests: check for exceptions also in fetcher diagnostics
    applied 57640e0be8f9... lttng-modules: fix v6.8+ build
    applied 6540f65a4ebb... linux-yocto-dev: update to v6.8
    applied 8e841dbcc37c... rpm: override curl executable search with just 'curl'
    applied 4cbec71b06e0... tune-cortexa78.inc: Add cortexa78 tune, based on cortexa77
    applied 4019e8ecf8d8... feature-arm-vfp.inc: Allow hard-float on newer simd targets
    applied 44f77871d3ee... tune-cortexr5: Add hard-float variant
    applied dd4c941e9fe9... tune-cortexr52: Add hard-float variant
    applied 11b804bbf1bd... kernel-devsrc: fix RDEPENDS for make
    applied 4c1eefd0c3de... kernel-devsrc: RDEPENDS on gawk
    applied b3d8881edd07... rpm: fix dependency for package config imaevm
    applied 66d0c928b90f... maintainers.inc: Add self for libseccomp and gnutls
    applied 46f235957b58... pseudo: Update to pull in gcc14 fix and missing statvfs64 intercept
    applied 83134a01ac51... numactl: upgrade 2.0.16 -> 2.0.17
    applied e1984c2e466f... mesa: Upgrade 23.3.4 -> 23.3.5
    applied 78c99af22c4b... eudev: allow for predictable network interface names
    applied 20aeb04f0223... at-spi2-core: upgrade 2.50.0 -> 2.50.1
    applied 4a9f9022bd62... cpio: upgrade 2.14 -> 2.15
    applied d13cc87bea6a... ethtool: upgrade 6.6 -> 6.7
    applied 64fe2cc801b3... iso-codes: upgrade 4.15.0 -> 4.16.0
    applied 57777b3df5cd... libinput: upgrade 1.24.0 -> 1.25.0
    applied 58fe3dab440c... libtest-warnings-perl: upgrade 0.032 -> 0.033
    applied 74709dcc2851... libwpe: upgrade 1.14.1 -> 1.14.2
    applied 9c262190b752... lzip: upgrade 1.23 -> 1.24
    applied 628750d2803c... createrepo-c: upgrade 1.0.2 -> 1.0.3
    applied 1342a35b0c9c... diffstat: upgrade 1.65 -> 1.66
    applied 8a03d734c2ca... dos2unix: upgrade 7.5.1 -> 7.5.2
    applied 6eb40b1bafeb... ed: upgrade 1.19 -> 1.20
    applied b0d34bdd61aa... gnupg: upgrade 2.4.3 -> 2.4.4
    applied 641369f677d7... gstreamer: upgrade 1.22.8 -> 1.22.9
    applied 5762e97b0190... libidn2: upgrade 2.3.4 -> 2.3.7
    applied f3fc26a2b40b... libpng: upgrade 1.6.40 -> 1.6.41
    applied dcfc159d4703... libsolv: upgrade 0.7.27 -> 0.7.28
    applied 8a0c1647395c... liburi-perl: upgrade 5.21 -> 5.25
    applied ea169466c9d3... nghttp2: upgrade 1.58.0 -> 1.59.0
    applied 50274c452195... repo: upgrade 2.40 -> 2.41
    applied 444a4a1c04a0... orc: upgrade 0.4.34 -> 0.4.36
    applied 8be2d9aa6853... pkgconf: upgrade 2.0.3 -> 2.1.0
    applied 47129c2fdda1... systemd: recommend libelf, libdw for elfutils flag
    applied a7ed494c4a0a... kexec-tools: Fix build with gas 2.42
    applied e41515b5f97d... systemtap: Backport GCC-14 related calloc fixes
    applied b73804429ca0... rpm: add missing dependencies for packageconfig
    applied 61b199d10319... libxml-parser-perl: upgrade 2.46 -> 2.47
    applied 34abe0219f19... sdk/assimp.py: Fix build on 32bit arches with 64bit time_t
    applied 670bc40b695d... openssl: Upgrade 3.2.0 -> 3.2.1
    applied 34c747f01777... conf: Move selftest config to dedicated inc file
    applied 0a9e45a41336... oeqa/selftest/bbtests: Tweak to use no-gplv3 inc file
    applied b6abbf4402ac... ltp: Update to 20240129
    applied f1921727d888... python3-markupsafe: upgrade 2.1.3 -> 2.1.5
    applied 3fda807ab006... python3-markupsafe: Switch to python_setuptools_build_meta
    applied 8c42532be568... curl: Update to 8.6.0
    applied 17a2c6e38d30... gtk: Set CVE_PRODUCT
    applied b0e5542e7a46... binutils: Upgrade to binutils 2.42
    applied 3558ee528f50... qemu-native: Use inherit_defer for including native class
    applied 25868ee2cc3f... qemu: Upgrade 8.2.0 -> 8.2.1
    applied c408737f046e... syslinux: Disable error on implicit-function-declaration
    applied 27d2c6dd1a59... bsp-guide: correct formfactor recipe name
    applied 596d5bb6fa04... migration-guide: add release notes for 4.0.16
    applied 8ae9a598ce22... dev-manual: gen-tapdevs need iptables installed
    applied c71f5236a4e3... contributor-guide: fix lore URL
    applied 4697b6454c0f... dev-manual: start: remove idle line
    applied 559313fe0307... docs: remove support for mickledore (4.2) release
    applied f4fc8e62321a... release-notes-4.3: fix spacing
    applied 6d503a7f3983... glibc: Upgrade to 2.39
    applied b94e596464be... glibc: Refresh CVE status w.r.t 2.39 release
    applied e71f54c6efe8... tunes/sve: Add support for sve2 instructions
    applied cc740bf63dcb... arm/armv*: add all the Arm tunes in GCC 13.2.0
    applied bca5c911a715... systemd: pack pre-defined pcrlock files installed with tpm2
    applied 9d2e7189e4e2... strace: Upgrade to 6.7
    applied 7c230aa0e9de... overlayfs: add missing closing parenthesis in selftest
    applied b0b9d8768a82... gnu-config: Update to latest version
    applied 6cc6246fd037... multilib_global.bbclass: fix parsing error with no kernel module split
    applied d0b817d946ba... patchtest-send-results: remove unused variable
    applied 149f42b59ea1... patchtest-send-results: properly parse test status
    applied 0513fd279c82... ltp: Enable extra test groups
    applied 5c55ed57e4f6... ltp: Try re-enabling problematic test
    applied 18e879ae05d2... meta-yocto-bsp: Remove accidentally added files
    applied 92d6170c32c3... oeqa/runtime: Move files from oe-core to bsp layer
    applied 9c1d226fadf7... patchtest.README: update mailing list
    applied e685773513df... wic: implement reproducible Disk GUID
    applied 3ef63361b43a... toolchain-shar-relocate: allow 'find' access to libraries in symlinked directories
    applied eda2fe2ac0e1... classes/package_rpm: additionally escape \ and " in filenames
    applied 57d82f92c106... classes/package_rpm: streamline the logic in one of the condition blocks
    applied eba805ace44c... tiff: fix CVE-2023-52355 and CVE-2023-52356
    applied 77f5f99fcfa2... package_manager: ipk: add OPKG_MAKE_INDEX_EXTRA_PARAMS variable
    applied 81d90fc81c09... package_rpm: add RPMBUILD_EXTRA_PARAMS variable
    applied 20b1e729e1b4... gnutls: print log if ptest fails
    applied d426872674ab... lzlib: add a recipe
    applied f66c8923c220... file: enable additional internal compressor support
    applied 346d40b99f5f... mirrors: Allow shallow glibc to work correctly
    applied 62049bfc7aae... ptest-packagelists: Mark python3 as problematic on riscv64
    applied d1ac9bb1bd21... testimage: retrieve ptests directory when ptests fail
    applied 4a6057d6a8e1... linux-yocto/6.6: features/qat/qat.cfg: enable CONFIG_PCIEAER
    applied b862b4aee48d... linux-yocto/6.6: beaglebone: drop nonassignable kernel options
    applied 7483b2fe7fcc... linux-yocto/6.6: update to v6.6.13
    applied e5f760b26fc3... linux-yocto/6.6: update CVE exclusions
    applied edc4785967a5... linux-yocto/6.6: can: drop obsolete CONFIG_PCH_CAN
    applied 6b052ffde3a2... linux-yocto/6.6: update to v6.6.15
    applied ac5f12517e74... linux-yocto/6.6: update CVE exclusions
    applied f31fe0b5b5c5... rust/cargo: Build fixes to rust for rv32 target
    applied bd7a3fd0f7a5... buildcpio.py: Switch to using cpio-2.15
    applied 2d4d362de104... ghostscript: correct LICENSE with AGPLv3
    applied 3ab7f0af56d0... ptest.bbclass: Handle the case when Makefile does not exist in do_install_ptest_base
    applied 58155ea1a346... bitbake: bitbake-diffsigs: fix walking the task dependencies and show better error
    applied 5276b7f548ef... bitbake: tests: fetch.py: use real subversion repository
    applied 18c4179d1160... kernel-devsrc: Add needed fixes for 6.1+ kernel build on target on RISCV
    applied 5ae7c6268b48... selftest/SStateCacheManagement: do not manipulate ERROR_QA
    applied a380d6d13702... selftest/SStateCacheManagement: pre-populate the cache
    applied 0c3818be2643... cmake: upgrade 3.27.7 -> 3.28.3
    applied 20fd415a5ab2... util-linux: add alternative link for scriptreplay
    applied a3c69c088eb6... uboot-sign: set load address and entrypoint
    applied 338a96e7c317... uboot-sign: Fix to install nonexistent dtb file
    applied 06aab81591bc... u-boot-sign:uboot-config: support to verify signed FIT image
    applied 277e65c3c843... python3: Fix ptests with expat 2.6+
    applied f2dcb4938e50... expat: Upgrade to 2.6.0
    applied 4a6a1a8c3c2e... kernel-devsrc: Clean up whitespace
    applied 6f2c3b77444d... lib/oeqa: rename assertRaisesRegexp to assertRaisesRegex
    applied 1d1d8b3f57f4... alsa-lib: upgrade 1.2.10 -> 1.2.11
    applied 6464ece7bb7a... alsa-tools: upgrade 1.2.5 -> 1.2.11
    applied a8cf6842ed46... alsa-ucm-conf: upgrade 1.2.10 -> 1.2.11
    applied be94979c6972... alsa-utils: upgrade 1.2.10 -> 1.2.11
    applied 233d2d8c0d29... recipetool: cleanup imports
    applied f58aedff022e... oeqa: replace deprecated assertEquals
    applied 5206056589ca... oeqa/selftest/recipetool: fix for python 3.12
    applied 71ac318a830b... yocto-bsp: update reference boards to v6.6.15
    applied e1f691072737... gcc-runtime: Move gdb pretty printer file to auto-load location
    applied 92d790f5c1ea... conf/machine: Add Power8 tune to PowerPC architecture
    applied 11ed2d14f90d... wireless-regdb: Upgrade 2023.09.01 -> 2024.01.23
    applied 3296f9a13d16... python3-numpy: upgrade 1.26.3 -> 1.26.4
    applied 54baffd407b5... libpcap: extend with nativesdk
    applied 353698169100... opkg: upgrade to 0.6.3
    applied 64ed7fdb53aa... opkg: add deprecation warning for internal solver
    applied a6136110b0ed... opkg-arch-config: update recipe HOMEPAGE
    applied df0a2575ec54... shadow: add a packageconfig for logind support
    applied f9ed2bdfdb2b... selftest/recipetool: Factor tomllib test to a function
    applied fcabbccd5f2f... selftest/recipetool: Improve test failure output
    applied 95cebcae0026... layer.conf: Update for the scarthgap release series
    applied 76575e760a84... layer.conf: Update for the scarthgap release series
    applied e834e8ee91b8... bitbake: support temporary AWS credentials
    applied 6a9aab565412... oeqa/runtime/cases: fix typo in information message
    applied 07006c486722... Revert "lzop: remove recipe from oe-core"
    applied 19687ca10cca... core-image-ptest: Increase disk size to 1.5G for strace ptest image
    applied 398f27cc0bba... oeqa/selftest/recipetool: downgrade meson version to not use pyproject.toml
    applied c472b4ce5990... recipetool: don't dump stack traces if a toml parser can't be found
    applied 465c25ce2ddb... patchtest-send-results: Add 'References' header
    applied 9e6e34210a3e... mirrors.bbclass: add infraroot as an https mirror
    applied 0010d9fbd25c... systemd.bbclass: Check for existence of the symlink too
    applied 21be9d1a4b15... python3-pyyaml: add PACKAGECONFIG for libyaml
    applied 38657590e74b... python3-pyyaml: enable ptest
    applied 0f50f21151f3... bitbake: process: Add profile logging for main loop
    applied 987ab2a446aa... bitbake: wget.py: always use the custom user agent
    applied 0ac07ddf71fe... bitbake: doc: README: simpler link to contributor guide
    applied babd5fea4a61... bitbake: process/server: Fix typo
    applied 598e1db8e63c... kernel-arch: Simplify strip support
    applied 9b5b62879979... insane: Clarify runtime/ warning
    applied 97eebe59d7ba... oeqa/selftest/oelib/buildhistory: git default branch
    applied 605ef6f5a292... scripts: python 3.12 regex
    applied 66850944957c... feature-microblaze-versions.inc: python 3.12 regex
    applied 7f2755daca55... meta/lib/oeqa: python 3.12 regex
    applied fe58da139306... meta/lib/patchtest: python 3.12 regex
    applied 83d5c123d3c5... meta/recipes: python 3.12 regex
    applied 80396cc72ac7... sanity.bbclass: raise_sanity_error if /tmp is noexec
    applied 78799643914c... tcmode-default: Do not define LLVMVERSION
    applied cceb8021020e... python3-sphinxcontrib-applehelp: upgrade 1.0.7 -> 1.0.8
    applied 0f8aa8c5f8d4... python3-sphinxcontrib-devhelp: upgrade 1.0.5 -> 1.0.6
    applied 484f3c295ea3... python3-sphinxcontrib-htmlhelp: upgrade 2.0.4 -> 2.0.5
    applied c84590f0b02a... python3-sphinxcontrib-qthelp: upgrade 1.0.6 -> 1.0.7
    applied 900dc520ca59... python3-sphinxcontrib-serializinghtml: upgrade 1.1.9 -> 1.1.10
    applied f6d6f1af1d3d... glibc: Update to latest on 2.39
    applied 5f449575be99... bmap-tools: Add missing runtime dependency
    applied 87798f82db80... ipk: Remove temporary package lists during SDK creation
    applied 1698249fc3a9... xz: remove redundant PTEST_ENABLED conditional
    applied 7b7a5f596fcd... libpam: remove redundant PTEST_ENABLED conditional
    applied 1a3f01cad47b... bitbake: bitbake/lib/bs4/tests/test_tree.py: python 3.12 regex
    applied a7bbb105d33c... bitbake: runqueue: Improve performance for executing tasks
    applied 71f55957f074... bitbake: runqueue: Optimise taskname lookups in next_buildable_task
    applied cdb1cb2ed8f6... bitbake: runqueue: Improve setcene performance when encoutering many 'hard' dependencies
    applied 6daa62c12498... python3-beartype: upgrade 0.16.4 -> 0.17.0
    applied 43161365c54b... python3-mako: upgrade 1.3.0 -> 1.3.2
    applied c60748947c58... python3-hatchling: upgrade 1.21.0 -> 1.21.1
    applied 92d3e56e26b8... python3-hypothesis: upgrade 6.92.9 -> 6.97.3
    applied b4265fa163b0... python3-pluggy: upgrade 1.3.0 -> 1.4.0
    applied 913d2891bcf4... python3-psutil: upgrade 5.9.7 -> 5.9.8
    applied b02c9ed25d6b... python3-pyopenssl: upgrade 23.3.0 -> 24.0.0
    applied 5007bd98ceed... python3-pytz: upgrade 2023.3 -> 2023.4
    applied b080cecd0567... glibc: Update to bring mips32/clone3 fix
    applied 1523bba26fd8... piglit: Fix build with musl
    applied f441e63de9d3... kexec-tools: Replace a submitted patch by the backported one
    applied 8f855f1e84a5... rootfs-postcommands: remove make_zimage_symlink_relative()
    applied c381ca72437a... lib/oe/package: replace in place PN-locale-* packages in PACKAGES
    applied c2a7c008e172... lib/oe/package: add LOCALE_PATHS to add define all locations for locales
    applied 8da6bd69dc2f... cups: use LOCALE_PATHS to split localized HTML templates
    applied 393da961be2c... glib-2.0: backport memory monitor test fixes
    applied a332f47bdb30... python3-cryptography: upgrade 41.0.7 to 42.0.2
    applied 54f660a5f665... python3: move dataclasses to python3-core
    applied 46fb0082dda2... qemu: disbale AF_XDP network backend support
    applied 0d1216207157... python3-unittest-automake-output: upgrade to 0.2
    applied b83bd953dae1... patchtest: log errors and failures at end
    applied 3a5e5742fcf8... mesa: update 23.3.5 -> 24.0.0
    applied 746bebb8dd61... meson: remove TMPDIR workaround
    applied b554ea9e36a3... tzdata : Upgrade to 2024a
    applied 0fe85ce0c670... busybox: Explicitly specify tty device for serial consoles
    applied 9382d731bdcb... bash: nativesdk-bash does not provide /bin/bash so don't claim to
    applied b1aaadb8286d... valgrind: make ptest depend on all components
    applied 04625c92a128... valgrind: update from 3.21.0 to 3.22.0
    applied 00c328db4d88... valgrind: skip 14 ptests in 3.22
    applied 29c9b8616289... valgrind: Skip 22 arm64 ptests
    applied 5c8e1e9955d6... patchtest-send-results: use Message-ID directly
    applied 5a93a3728e3f... ptest-runner: Bump to 2.4.3 (92c1b97)
    applied 896a48075840... mesa: update 24.0.0 -> 24.0.1
    applied 0de05c35bdd1... openssh: upgrade 9.5p1 -> 9.6p1
    applied 2774954f7eb6... openssh: Add a work around for ICE on mips/mips64
    applied f3a72a286227... python3-poetry-core: upgrade 1.8.1 -> 1.9.0
    applied 37aa0e077ad3... devtool: modify: Correct appending of type=git-dependency to URIs
    applied c3b895e94301... zlib: upgrade 1.3 -> 1.3.1
    applied 1e0cf2db7cb4... xz: upgrade 5.4.5 -> 5.4.6
    applied 6d6a92471864... patchtest: Fix grammar in log output
    applied 122401ce482f... patchtest-send-results: add --debug option
    applied e898f65b339a... waf.bbclass: Print waf output on unparsable version
    applied 33255c6af06b... llvm: Upgrade to LLVM-18 RC2
    applied a4fd595a2b15... meta/conf/templates/default/conf-notes.txt: remove
    applied 353fb8f18fe0... kernel-devsrc: Improve vdso-offsets handling for qemuriscv64
    applied 2cdeadd1ff5f... u-boot: Pass in prefix mapping variables to the compiler
    applied 0684f971c351... sstate-cache-management: fix regex for 'sigdata' stamp files
    applied ab0c12e9ea31... linux-yocto/6.6: update to v6.6.16
    applied f9739740a417... linux-yocto/6.6: update CVE exclusions
    applied 1aa0279aa460... linux-yocto/6.6: qemuriscv: enable goldfish RTC
    applied 658822409255... meson: set the sysroot in the cross files
    applied 327930552e77... python3-pytest: upgrade 7.4.4 -> 8.0.0
    applied 3b9dbfb5c6f9... python3-attrs: skip test failing with pytest-8
    applied 53dd45d573fd... binutils: Update to tip of 2.42 release branch
    applied 6088f280dbb7... ldconfig-native: Fix to point correctly on the DT_NEEDED entries in an ELF file
    applied 00811a39265a... libadwaita: update 1.4.2 -> 1.4.3
    applied 65da465410c2... libffi: upgrade to 3.4.5
    applied a6236e44fcd7... enchant2: upgrade 2.6.5 -> 2.6.7
    applied c7557f29abff... libproxy: upgrade 0.5.3 -> 0.5.4
    applied 86351a1e8921... sqlite3: upgrade 3.44.2 -> 3.45.1
    applied cf08dfaf2791... orc: upgrade 0.4.36 -> 0.4.37
    applied e61afce99efd... stress-ng: upgrade 0.17.04 -> 0.17.05
    applied ee3541ca8a9c... libcap-ng: fix build with swig 4.2.0
    applied a277d1f7a0dc... gstreamer1.0: upgrade 1.22.9 -> 1.22.10
    applied f909d235c95d... sstate.bbclass: Only sign packages at the time of their creation
    applied 3ccb4d8ab1d7... devtool: new ide-sdk plugin
    applied 946cac328aa5... oe-selftest devtool: ide-sdk tests
    applied 539c8801265d... devtool: ide-sdk make deploy-target quicker
    applied 890446392b20... devtool: standard: Add some missing whitespace
    applied 3c08950557aa... testsdk: Avoid PATH contamination
    applied f62e4d81ec58... bitbake: taskexp_ncurses: ncurses version of taskexp.py
    applied c75421861462... oeqa/selftest/rust: Exclude failing riscv tests
    applied dc87dcffd317... grub2: ignore CVE-2024-1048, Redhat only issue
    applied 591406e75645... libgit2: update 1.7.1 -> 1.7.2
    applied 3f9e81af2113... vim: upgrade from 9.0.2130 -> 9.1.0114
    applied 33216d08f742... gnupg: disable tests to avoid running target binaries at build time
    applied 09839f6a8a7b... devtool: _extract_source: Correct the removal of an old backup directory
    applied a510d455d3b9... vscode: drop .vscode folder
    applied dfe98713729c... oe-init-build-env: generate .vscode from template
    applied 3b69f7b07922... libuv: Upgrade 1.47.0 -> 1.48.0
    applied f25849c7689a... wayland-protocols: update 1.32 -> 1.33
    applied 378bc2f8e3ac... qemu: Set CVE_STATUS for wrong CVEs
    applied 9813515ff264... useradd.bbclass: Fix missing space when appending vardeps.
    applied a4b5a2d5b7ff... scripts/oe-setup-layers: write a list of layer paths into the checkout's top dir
    applied 728b9ba88e65... patchtest: Add selftest for test cve_check_ignore
    applied 0ba7038c09fa... patchtest: add stronger indication for failed tests
    applied 6f29e2319cf8... meta/conf/templates/default/conf-summary.txt: add a template summary
    applied f6f50200c97f... meta/lib/bblayers/buildconf.py: add support for configuration summaries
    applied 01d0ee1b834e... scripts/oe-setup-builddir: add support for configuration summaries
    applied c390b2e61593... oe-setup-build: add a tool for discovering config templates and setting up builds
    applied dd2ed0c3630a... bitbake-layers: Add ability to update the reference of repositories
    applied 0fba76e5ad51... bitbake-layers: Add test case layers setup for custom references
    applied fd600728ffd8... meta-poky/conf/templates/default/conf-summary.txt: add a template summary
    applied 324c9fd66611... bitbake: hashserv: improve the loglevel error message to be more helpful
    applied 1effd1014d91... bitbake: hashserv: Add Unihash Garbage Collection
    applied be909636c608... bitbake: hashserv: sqlalchemy: Use _execute() helper
    applied 3bd2c69e7085... bitbake: hashserv: Add unihash-exists API
    applied 2406bd105509... bitbake: asyncrpc: Add Client Pool object
    applied 37b4d7e4931c... bitbake: hashserv: Add Client Pool
    applied e5056394e030... bitbake: siggen: Add parallel query API
    applied 61e184b3ed4d... bitbake: siggen: Add parallel unihash exist API
    applied 4e673ccb00d9... bitbake: bitbake: hashserv: Postgres adaptations for ignoring duplicate inserts
    applied eca5708b8734... bitbake: bitbake: Bump version to 2.7.3 for hashserv changes
    applied ba68f3132d19... sstatesig: Implement new siggen API
    applied a5b23365539b... sanity.conf: Require bitbake 2.7.3
    applied b3d9663817c8... bitbake: fetch/git2: support git's safe.bareRepository
    applied 577e73606acc... bitbake: tests/fetch: support git's safe.bareRepository
    applied e6892bc47a5a... bitbake: git-make-shallow: support git's safe.bareRepository
    applied b2d0f31d2484... bitbake: fetch2/git.py: Fetch mirror into HEAD
    applied de27ecd228e2... bitbake: tests/fetch.py: add multiple fetches test
    applied 8a531d199096... initramfs-framework: overlayroot: fix kernel commandline clash
    applied e6047ee5e8b8... initramfs-framework: overlayroot: align bootparams with module name
    applied 6cddb77eee27... ell: update 0.61 -> 0.62
    applied c984b03f0275... bitbake: fetch2/git.py: fix a corner case in try_premirror
    applied 09ecbcd307ee... bitbake: tests/fetch.py: add test case for using premirror in restricted network
    applied 272d5ae098e3... bitbake: fetch2/git.py: add comment in try_premirrors
    applied 21603031df33... bitbake: tests/fetch: Make test_git_latest_versionstring support a max version
    applied 9694fe1d684e... bitbake: fetch2/git: A bit of clean-up of latest_versionstring()
    applied d25f6b970fbe... bitbake: fetch2/git: Make latest_versionstring extract tags with slashes correctly
    applied 6f32769afbc8... overlayfs-etc: add option to skip creation of mount dirs
    applied 1e6565402f93... swig: upgrade 4.1.1 -> 4.2.0
    applied 24433ce8f9e0... lib/oe/patch: Make extractPatches() not extract ignored commits
    applied ff63bc403dd8... lib/oe/patch: Add GitApplyTree.commitIgnored()
    applied 85b5e87c7de6... devtool: Make use of oe.patch.GitApplyTree.commitIgnored()
    applied dc2e09417d17... patch.bbclass: Make use of oe.patch.GitApplyTree.commitIgnored()
    applied 4cfd0f7e4e2d... lib/oe/patch: Use git notes to store the filenames for the patches
    applied 0b33104a973c... python: Drop ${PYTHON_PN}
    applied 03f3aa643a0d... python3-pyproject-metadata: move from meta-python
    applied 3e808c075f61... python3-pyproject-metadata: HOMEPAGE; DESCRIPTION
    applied c0a2e3a9664f... python3-meson-python: move from meta-python
    applied a7484a66b42b... python_mesonpy.bbclass: move from meta-python
    applied 9f7475b4e521... recipetool; add support for python_mesonpy class
    applied 1648d0e8f732... insane.bbclass: Allow the warning about virtual/ to be disabled
    applied fb6975816423... libsdl2: upgrade 2.28.5 -> 2.30.0
    applied 468e55069219... bash: rebase the patch to fix ptest failure
    applied 730bd999d641... bitbake: Revert "bitbake: wget.py: always use the custom user agent"
    applied 8e84fbba7270... devtool: ide_sdk: Use bitbake's python3 for generated scripts
    applied c0d340c52e6f... devtool: ide: vscode: Configure read-only files
    applied fc8e5d7c13f6... meson: use absolute cross-compiler paths
meta-arm 6bb1fc8d8c -> 025f76a14f:
    applied b422688735de... arm/opencsd: update to v1.5.1
    applied 5a78c75f3544... arm/optee: update to 4.1
    applied d1f059782246... arm-bsp/optee: remove unused v3.22.0 recipes
    applied 827129b05b22... CI: support extra kas files from environment
    applied a91ddf486980... CI/cve.yml: add a CVE-checking Kas fragment
    applied c5e288d1bba4... n1sdp:arm arm-bsp: fix tftf tests for n1sdp
    applied 8b94fee2058d... CI: add explanatory comments to variables
    applied 60202ad84d3d... CI: allow the runner to set a NVD API key
    applied 145bb3486530... arm-bsp/u-boot:corstone1000: Fix deployment of capsule files
    applied 12e3e2b9c681... arm-bsp/documentation: corstone1000: fix typo
    applied 73dae39ad27b... arm-bsp/optee: upgrade optee to 4.1.0 for N1SDP
    applied 238a6f1ebf01... CI: use https: to fetch meta-virtualization
    applied 9975a3b3d94b... layer.conf: Update for the scarthgap release series
    applied 39ceb873242c... bsp: Move Corstone-1000 U-Boot configuration entries
    applied 79c809ab5709... bsp: Move machine settings
    applied 036274b3fb9b... bsp,ci: Switch to poky distro
    applied 025f76a14f6c... bsp: Rename corstone1000-image
meta-security b2e1511338 -> 30e755c592:
    applied 7fab92b3c065... parsec-tool: fix serialNumber check
    applied 79b5f135a831... meta-security: libhoth: SRCREV bump e520f8f...e482716
    applied 4982aa40b7e0... python3-pyinotify: do not rely on smtpd module
    applied d25b34839477... python3-fail2ban: remove unused distutils dependency
    applied 3791852532a7... scap-security-guide: update to 0.1.71
    applied d444b7d7dad2... linux-yocto%.bbappend: Add audit.cfg
    applied 06979d554847... integrity-image-minimal: Fix IMAGE_INSTALL
    applied 6f7f2b6b470a... openscap: fix build with python 3.12
    applied 5d2bd6bbb571... checksec: Add more runtime dependencies to checksec tool
    applied 30e755c59204... lynis: Add missing runtime dependencies
meta-raspberrypi 9c901bf170 -> dbf1113a82:
    applied 99a1b4b5fad8... linux-raspberrypi_6.1.bb: Upgrade to 6.1.74
    applied e67feeff489a... libcamera-apps: fix build with libcamera-0.2.0
    applied fc34bc3b86f9... rpi-base: Add missing hifiberry overlay
    applied 6d7c2f80800c... linux-raspberrypi: Upgrade to 6.1.77
    applied 54f6b3c660ad... layer.conf: Update for the scarthgap release series
    applied 2e1ca4ce2e4c... rpidistro-ffmpeg: Fix old override syntax
    applied dbf1113a8277... rpi-eeprom_git: v.2024.01.05-2712 Update recipe to latest rpi-eeprom repo This follows the current latest release of rpi-eeprom: https://github.com/raspberrypi/rpi-eeprom
meta-openembedded 9953ca1ac0 -> 528f273006:
    applied d25486ee191a... libtalloc, libtevent, libtdb, libldb: set PYTHONARCHDIR for waf to respect python libdir
    applied 271e77507324... dropwatch: add new recipe
    applied c26b1dcc4ad3... luajit: allow to build on supported platforms
    applied 430c984cd9b1... btop: upgrade 1.2.13 -> 1.3.0
    applied d5b38f9d099e... ccid: upgrade 1.5.4 -> 1.5.5
    applied da580d959fb7... ctags: upgrade 6.1.20231231.0 -> 6.1.20240114.0
    applied d34f54d0876a... gcr3: upgrade 3.41.1 -> 3.41.2
    applied 110667ac3798... htop: upgrade 3.2.2 -> 3.3.0
    applied ad1ca866e7e1... hwdata: upgrade 0.377 -> 0.378
    applied 2c17186c02ce... libdecor: upgrade 0.2.1 -> 0.2.2
    applied acfdff6e41f8... libvpx: upgrade 1.13.1 -> 1.14.0
    applied f8058e2efb72... lldpd: upgrade 1.0.17 -> 1.0.18
    applied d75e356f3361... gjs: upgrade 1.78.2 -> 1.78.3
    applied 69dbecded170... wireshark: upgrade 4.2.0 -> 4.2.2
    applied c1e3429d596a... capnproto: upgrade 1.0.1.1 -> 1.0.2
    applied 4d65c185b2f3... dnfdragora: upgrade 2.1.5 -> 2.1.6
    applied 535c83050966... libyang: upgrade 2.1.128 -> 2.1.148
    applied e6bfe7668d4c... lshw: upgrade 02.19.2 -> 02.20
    applied 3fd4d0e8533f... md4c: upgrade 0.4.8 -> 0.5.0
    applied b35224e19149... python3-apscheduler: add new recipe
    applied e91fa668ed1d... redis: upgrade 7.2.3 -> 7.2.4
    applied 12441b57393a... sanlock: upgrade 3.8.5 -> 3.9.0
    applied f389b4249812... python3-eth-keys: upgrade 0.4.0 -> 0.5.0
    applied 92c941986dd8... python3-xmlschema: upgrade 2.5.1 -> 3.0.1
    applied 3616b8972711... plocate: upgrade 1.1.20 -> 1.1.22
    applied 0007269307a0... python3-absl: upgrade 2.0.0 -> 2.1.0
    applied af995f726d54... python3-asyncinotify: upgrade 4.0.5 -> 4.0.6
    applied cbf8e692a53d... python3-beautifulsoup4: upgrade 4.12.2 -> 4.12.3
    applied fa0393d5cb75... python3-cantools: upgrade 39.4.2 -> 39.4.3
    applied 2ae55ae7e043... python3-cbor2: upgrade 5.5.1 -> 5.6.0
    applied 8e156d5b4fea... python3-dbus-fast: upgrade 2.21.0 -> 2.21.1
    applied 90e6f9734488... python3-django: upgrade 5.0 -> 5.0.1
    applied 3232cea58cd5... python3-eth-abi: upgrade 4.2.1 -> 5.0.0
    applied 6f325c9801e3... python3-eth-typing: upgrade 3.5.2 -> 4.0.0
    applied 613b9e713a01... python3-eth-utils: upgrade 2.3.1 -> 3.0.0
    applied ae99cb9a248f... python3-eventlet: upgrade 0.34.2 -> 0.34.3
    applied 3d9d4a1c02b2... python3-flask: upgrade 3.0.0 -> 3.0.1
    applied 9dbecd2cb811... python3-git-pw: upgrade 2.5.0 -> 2.6.0
    applied 344bf1d45bb6... python3-google-api-python-client: upgrade 2.113.0 -> 2.114.0
    applied a34c666a9ef7... python3-haversine: upgrade 2.8.0 -> 2.8.1
    applied 6fd856883c94... python3-ipython: upgrade 8.19.0 -> 8.20.0
    applied e403316c5a88... python3-pdm: upgrade 2.11.2 -> 2.12.1
    applied 421ca9445591... python3-pyatspi: upgrade 2.46.0 -> 2.46.1
    applied a08268e86642... python3-sentry-sdk: upgrade 1.39.1 -> 1.39.2
    applied a8ec8dffa8a4... python3-robotframework: upgrade 6.1.1 -> 7.0
    applied d2cc59cb5968... python3-pychromecast: upgrade 13.0.8 -> 13.1.0
    applied 8da761a36b8c... python3-tox: upgrade 4.11.4 -> 4.12.1
    applied eac87d0afd30... python3-types-psutil: upgrade 5.9.5.17 -> 5.9.5.20240106
    applied 005bd377db1e... qpdf: upgrade 11.7.0 -> 11.8.0
    applied 7c9ee243b3b5... smemstat: upgrade 0.02.12 -> 0.02.13
    applied cb0c748ebe53... tesseract: upgrade 5.3.3 -> 5.3.4
    applied d441057a051e... uftrace: Upgrade to 0.15.2
    applied 8f479b898afd... i2cdev: Set PV correctly
    applied 2366c4bc2d6c... libsmi: Fix buildpaths warning.
    applied 437703d59d40... minicoredumper: upgrade 2.0.6 -> 2.0.7
    applied 855b4182a5c1... minicoredumper: Fix build with clang
    applied 51392e0d1438... python3-pytest-mock: Fix ptest failures with python 3.12
    applied 793098cf0348... ndctl: Update to v78
    applied 1008d54e1f36... radvd: add '--shell /sbin/nologin' to /etc/passwd
    applied b3d3f26adc87... python3-flask-marshmallow: upgrade 0.15.0 -> 1.1.0
    applied 996d41396aaa... vk-gl-cts: Disable Werror on amber external module
    applied 542c2a23d6ef... vulkan-cts: Upgrade to 1.3.7.3
    applied 301a67da6a5e... python3-netaddr: upgrade 0.10.0 -> 0.10.1
    applied 711c6fbce39d... libcamera: update 0.1.0 -> 0.2.0
    applied 10c75cbde1be... pipewire: fix build with libcamera-0.2
    applied 2c6caea18f96... jack: fix build with python3 on host
    applied 02806ed4c16d... kernel-selftest: Add few more testcases
    applied 1d125e17798f... uutils-coreutils: upgrade 0.0.23 -> 0.0.24
    applied 0bea9feffc93... uutils_coreutils: merge .inc and .bb
    applied a67803876679... polkit: fix rules.d permissions
    applied e88210eae3bd... xdg-desktop-portal: add missing glib-2.0-native dependency
    applied b5808a874714... python3-bandit: update to version 1.7.7
    applied c059c947b05b... python3-web3: update to version 6.15.0
    applied 058d055bfe1a... python3-argcomplete: update to version 3.2.2
    applied db457ada250b... python3-cytoolz: update to version 0.12.3
    applied 444ec342feb1... python3-pdm: update to version 2.12.2
    applied 32be2bd921bd... python3-google-api-python-client: update to version 2.115.0
    applied 7284093cac87... python3-coverage: update to version 7.4.1
    applied b0bdf96942c1... python3-gmqtt: update to version 0.6.14
    applied 5e69de6d129e... python3-colorlog: update to version 6.8.2
    applied 788399ea001b... python3-argh: update to version 0.31.2
    applied 49f53ac04134... scapy: Add difftools and logutils in RDEPENDS
    applied 49f764e617aa... python3-toolz: upgrade 0.12.0 -> 0.12.1
    applied dea8afa45ef5... uftrace: Adjust the summary to reflect rust and python support
    applied ede8aef105a1... system-config-printer: fix runtime for system-config-printer
    applied 1f8dc17b7cc7... bonnie++: New recipe for version 2.0
    applied af3496bf3177... python3-aiohappyeyeballs: add recipe
    applied 06e75957c54e... python3-aiohttp: upgrade 3.9.1 -> 3.9.2
    applied ca7dccfce81b... iwd: update 2.8 -> 2.13
    applied 5683a9c54ac0... flatcc: Add tool recipe
    applied 9116fa164908... python3-eth-rlp: upgrade 1.0.0 -> 1.0.1
    applied 82237bb316cf... redis: restore Upstream-Status
    applied 30f7287119c7... libvpx: restore Upstream-Status
    applied 9ae4f0695d09... python-jsonref: add missing Upstream-Status
    applied 48c7cd6d11d9... python3-janus: add recipe for v1.0.0
    applied 0ffbe2a79a5d... ibus: backport a reproducibility fix
    applied 4cefe0196f7a... php-fpm: fix systemd
    applied 2aaf6b75a958... libcamera: Fix build with clang-18
    applied 02fe2e388ee9... breakpad: Upgrade to 2023.06.01 release
    applied dfb5a96169eb... bpftool: Add missing dep on elfutils-native
    applied 9e96cb9d12b6... python3-aiohttp: upgrade 3.9.2 -> 3.9.3
    applied f0512636fdaa... cmocka: Fix install conflict when enable multilib.
    applied bb4884b416ba... mdns: Fix SIGSEGV during DumpStateLog()
    applied b4d8d8626efa... python3-google-auth-oauthlib: add recipe
    applied b239853fd3bd... flatcc: Fix build warnings found with clang-18
    applied 14e2e3a43477... czmq: Fix install conflict when enable multilib.
    applied df2cf2d3664a... czmq: Fix buildpaths warning.
    applied c1fce9e3987d... python3-luma-core: update to version 2.4.2
    applied 902de1d5ac23... python-pdm: update to version 2.12.3
    applied 7e7e7826e148... python3-parse: update to version 1.20.1
    applied 546a86619a49... python3-grpcio: update to version 1.60.1
    applied 92f93d603368... python3-dill: update to version 0.3.8
    applied 0f7c4c209531... python3-types-setuptools: update to version 69.0.0.20240125
    applied 847a5d1fa073... python3-pymisp: update to version 2.4.184
    applied 85932ac50e3e... python3-cbor2: update to version 5.6.1
    applied 2ffb6d2dc95f... python3-sentry-sdk: update to version 1.40.0
    applied fe658dde0658... python3-pytest-asyncio: update to version 0.23.4
    applied b09e0bc055ff... python3-google-api-core: update to version 2.16.1
    applied 3630a7991e2f... python3-google-api-python-client: update to version 2.116.0
    applied cc3537fa900a... python3-google-auth: update to version 2.27.0
    applied f13462298610... python3-jsonrpcclient: update to version 4.0.3
    applied 6e2770abe8c7... python3-dnspython: update to version 2.5.0
    applied ba24b8ca4fcf... python3-eventlet: update to version 0.35.1
    applied be4721a95513... python3-platformdirs: update to version 4.2.0
    applied 8185be6fd9b3... python3-ipython: update to version 8.21.0
    applied 97b762e4315a... python3-grpcio-tools: update to version 1.60.1
    applied 1fab428c136e... python3-cachecontrol: update to version 0.14.0
    applied 89cba3b83cd4... python3-binwalk: update the regex version for upstream checks
    applied 277501596746... python3-pymodbus: update to version 3.6.3
    applied fb98797c9647... python3-moteus: add recipe for v0.3.67
    applied 8c327fadfa0d... cpuid: fix do_install
    applied a8714fd4a6d1... python3-scikit-build: upgrade 0.16.7 -> 0.17.6
    applied 3c6b9945629d... python3-pychromecast: add missing RDEPENDS, and add initial recipe for dependency.
    applied 8371516578c0... syslog-ng: ignore CVE-2022-38725
    applied 184e1a4469bd... Revert "lzop: add (from oe-core)"
    applied e73a360455a9... e2tools: Add tool recipe
    applied 3918a94eb50c... ostree: Upgrade 2023.8 -> 2024.1
    applied 0f1629611c93... pipewire: update 1.0.1 -> 1.0.3
    applied c11ba7a08a44... python3-eth-account: upgrade 0.10.0 -> 0.11.0
    applied b1e57692e04a... mbedtls: upgrade 3.5.1 -> 3.5.2
    applied f51fe152e802... mbedtls: upgrade 2.28.4 -> 2.28.7
    applied b7b9115e68a8... bdwgc: upgrade 8.2.4 -> 8.2.6
    applied d52bb0212c62... cmark: upgrade 0.30.3 -> 0.31.0
    applied 3846f9d7e927... gensio: upgrade 2.8.2 -> 2.8.3
    applied d2d364eab85d... geos: upgrade 3.12.0 -> 3.12.1
    applied 4a27f91f13d2... imlib2: upgrade 1.12.1 -> 1.12.2
    applied 9c809c013680... libcbor: upgrade 0.10.2 -> 0.11.0
    applied 69076d85460d... libinih: upgrade 57 -> 58
    applied ec23bd228902... libio-socket-ssl-perl: upgrade 2.084 -> 2.085
    applied 364841f4eb02... libjcat: upgrade 0.2.0 -> 0.2.1
    applied 9ebcca573483... libqmi: upgrade 1.35.1 -> 1.35.2
    applied af4bce0de3f5... md4c: upgrade 0.5.0 -> 0.5.2
    applied 70e5584a4d93... nanomsg: upgrade 1.2 -> 1.2.1
    applied ea9c6e8982d1... neatvnc: upgrade 0.7.1 -> 0.7.2
    applied 18933571778f... network-manager-applet: upgrade 1.34.0 -> 1.36.0
    applied 016726c5b8d1... libgsf: upgrade 1.14.51 -> 1.14.52
    applied 3fe7c5fae857... ndisc6: upgrade 1.0.7 -> 1.0.8
    applied a178f67d972b... squid: upgrade 6.6 -> 6.7
    applied 41b210079fde... iotop: upgrade 1.25 -> 1.26
    applied 933e9a58ef45... libblockdev: upgrade 3.0.4 -> 3.1.0
    applied aaface8243da... neon: upgrade 0.32.5 -> 0.33.0
    applied a117518af6d3... pkcs11-provider: upgrade 0.2 -> 0.3
    applied 78a043ebf8db... sanlock: upgrade 3.9.0 -> 3.9.1
    applied 8b7ad24b0197... satyr: upgrade 0.42 -> 0.43
    applied d550f932ac92... python3-astroid: upgrade 3.0.2 -> 3.0.3
    applied 003c1900a8d2... python3-elementpath: upgrade 4.1.5 -> 4.2.0
    applied 403ee4b64231... python3-flask: upgrade 3.0.1 -> 3.0.2
    applied 39c5f67eae6f... python3-google-api-core: upgrade 2.16.1 -> 2.16.2
    applied 79b34cb5568f... python3-gspread: upgrade 5.12.4 -> 6.0.0
    applied 8c0e8ceceb98... python3-path: upgrade 16.9.0 -> 16.10.0
    applied 8540c5e5172f... python3-gcovr: upgrade 6.0 -> 7.0
    applied 37da936b5b24... flatcc: respect baselib
    applied c5c28d716bf8... flatcc: drop 'r' from gitr and ${SRCPV}
    applied ff20e6c783fb... proj: extend class to native and nativesdk
    applied e3489d11504b... proj: upgrade 9.3.0 -> 9.3.1
    applied 21f956598ddb... recipes: drop ${SRCPV} usage
    applied d3d099bda6a4... recipes: drop remaining +gitr cases
    applied 3482f8973ec4... gitpkgv.bbclass: adjust the example in comment a bit
    applied 10703e5c6a51... ne10: append +git instead of gitr+
    applied 347d5273dcf9... evemu-tools: use better PV
    applied a058fef24987... python3-aiodns python3-pycares: Add native & nativesdk support
    applied 07f5ff1f600d... python3-aiohappyeyeballs: Add native & nativesdk support
    applied 4ca4d0cc8194... python3-types-psutil: upgrade 5.9.5.20240106 -> 5.9.5.20240205
    applied 131060d7c06b... python3-waitress: upgrade 2.1.2 -> 3.0.0
    applied a10ba0957910... rdma-core: upgrade 48.0 -> 50.0
    applied f203db0af8af... ser2net: upgrade 4.6.0 -> 4.6.1
    applied dae0a0d77a5d... sip: upgrade 6.8.1 -> 6.8.2
    applied 890f24333208... span-lite: upgrade 0.10.3 -> 0.11.0
    applied aa6b8afbbc25... tcpslice: upgrade 1.6 -> 1.7
    applied 941f2a621513... python3-pyunormalize: add recipe
    applied 7e45304132af... python3-web3: upgrade 6.15.0 -> 6.15.1
    applied fd53a86d2c63... rtkit: missing files/directories in package
    applied c4898368377a... can-isotp: Update to latest and skip it
    applied 59bffb68440c... openflow: Switch SRC_URI to github mirror
    applied 192f412b3d67... ot-br-posix: upgrade to latest trunk
    applied bc5c3e48c15d... libcereal: Disable c++11-narrowing-const-reference warning as error
    applied ae8d97707663... python3-gspread: upgrade 6.0.0 -> 6.0.1
    applied 5a45aa504a37... python3-strenum: add recipe
    applied d43386035a9c... nana: upgrade to latest commit from github
    applied a708f2da48af... xfstests: upgrade to latest 2024.01.14
    applied 52fe689c2d50... xfstests: add gawk to RDEPENDS
    applied 5057523005cc... xfstests: use master branch instead of 'for-next'
    applied 8e5f98be3529... xfstests: drop the upstream rejected install-sh hack
    applied e8a1c9823b7e... xfstests: fix make install race condition
    applied d5dbc6b6a55c... python3-tzlocal: Add zoneinfo dependency
    applied 4f2aa6569cc3... radvd: Fix build in reproducible test
    applied 713d917cc6ba... python3-flask-marshmallow: upgrade 1.1.0 -> 1.2.0
    applied 45ae16dbcdb5... nodejs: Set CVE_PRODUCT to "node.js"
    applied 421c31515307... python3-werkzeug: upgrade 2.3.6 -> 3.0.1
    applied 065d6496e4af... mariadb: Move useradd handling in target side of the recipe
    applied a66451823fd0... dvb-apps: no longer skip ldflags QA
    applied 6ab716910e86... etcd-cpp-apiv3: no longer skip ldflags QA
    applied 34065357cb50... opencv: upgrade 4.8.0 -> 4.9.0
    applied 24b2848f0423... kernel-selftest: no longer skip ldflags QA
    applied f0d3a2bc867a... nanopb: Update 0.4.7 -> 0.4.8
    applied 30bb83b306db... nanopb: Split into 2 packages
    applied 341c47848d04... nanopb-runtime: Enable shared library
    applied 4dc83a7eff03... mdns: Upgrade 2200.60.25.0.4 -> 2200.80.16
    applied cd12fddddd42... c-ares: Upgrade 1.24.0 -> 1.26.0
    applied 6d766dd2b080... python3-socksio: add recipe for v1.0.0
    applied 7e95b8600e30... python3-anyio: add recipe for v4.2.0
    applied 057781a73316... python3-sniffio: add recipe for v1.3.0
    applied 704b091001c7... python3-httpcore: add recipe for v1.0.2
    applied fe06ca23194c... python3-httpx: add recipe for v0.26.0
    applied a6c4624a684f... ot-br-posix: Limit vla-cxx-extension option to clang >= 18
    applied 1548cf77df95... python3-imageio: upgrade 2.33.1 -> 2.34.0
    applied 50054e7ab1e1... flatpak: remove unneeded RDEPENDS
    applied bddecd156074... libosinfo: use hwdata for ids files
    applied 6ddb9b486f49... whitenoise: add a new recipe
    applied 2f185f00d299... libnfs: update 5.0.2 -> 5.0.3
    applied 10add4b12b8c... python3-werkzeug: add missing runtime dependencies
    applied 399531aa0950... switchtec-user: upgrade 4.1 -> 4.2
    applied c9ddb71d35c6... signing.bbclass: make it work with eliptic curve keys
    applied 6b2b1c667053... kexec-tools-klibc: Fix building on x86_64 with binutils 2.41
    applied 6d49a5c8dd1f... hwdata: update 0.378 -> 0.379
    applied 28cf32275137... python3-pybind11: Amend HOMEPAGE
    applied 67d30ca64a4f... python3-pybind11: Prune redundant inherit
    applied 9b67d8127665... python3-pybind11: Fix LICENSE
    applied 669404fcdb96... python3-pybind11: Cosmetic fixes
    applied 9e13a6ac3e2b... nodejs: update to latest v20 version 20.11.0
    applied b149b1e6a1de... opencv: Fix python3 package generation
    applied d3957c4f98f6... libnvme: upgrade 1.7.1 -> 1.8
    applied b0d1ba544a73... nvme-cli: upgrade 2.7.1 -> 2.8
    applied bf011a9f5e89... python3-pyyaml-include: add initial recipe for version 1.3.2
    applied 066f509f15d7... plymouth: uprev to 24.004.60
    applied 0b6224a322a7... libusbgx: fix usbgx.service stop / restart
    applied 79e453960118... libusbgx: uprev to the latest commit
    applied 7e0ce9b5e7e0... libqmi: correct PV
    applied e3785b50fd7d... xfstests: Only specify the main SRCREV once
    applied 6be4e223cb7d... python3-django: upgrade to Django 4.2.10 LTS release
    applied 2af10b735148... python3-appdirs: add ptest into PTESTS_FAST_META_PYTHON items
    applied b08e67ae986c... python3-yarl: add ptest into PTESTS_FAST_META_PYTHON items
    applied e183db0c8f0b... python3-ujson: add ptest into PTESTS_FAST_META_PYTHON items
    applied 086eeb45d4dd... python3-pybind11: Remove the Boost dependency
    applied c274202e3cab... python3-uritemplate: switch to pytest --automake
    applied 19412dc78d8a... python3-unidiff: switch to pytest --automake
    applied 521805187926... python3-ujson: switch to pytest --automake
    applied 21938d943226... python3-pytest-lazy-fixture: switch to pytest --automake
    applied d114bafa718c... python3-fastjsonschema: switch to pytest --automake
    applied 82561d6a3d48... python3-tomlkit: switch to pytest --automake
    applied 9b8e0ebb5903... python3-inotify: switch to pytest --automake
    applied e53f237ba457... python3-requests-file: switch to pytest --automake
    applied a2af67f5d7cf... python3-covdefaults: switch to pytest --automake
    applied 96f5c7521986... python3-dominate: switch to pytest --automake
    applied 3e1caf55ef79... python3-scrypt: switch to pytest --automake
    applied c96ff70bd6aa... python3-u-msgpack-python: switch to pytest --automake
    applied 5cb0fc02c16b... python3-iso3166: switch to pytest --automake
    applied 4a392ddd3b27... python3-trustme: switch to pytest --automake
    applied a600e4bb3c70... python3-asgiref: switch to pytest --automake
    applied aaa00e26053c... python3-html2text: switch to pytest --automake
    applied 4201621f4574... python3-pyasn1-modules: switch to pytest --automake
    applied be7a44fecc14... python3-intervals: switch to pytest --automake
    applied a923a232d8cb... python3-py-cpuinfo: switch to pytest --automake
    applied 5f6e352b2711... python3-backports-functools-lru-cache: drop folder
    applied 0ba05a291773... python3-whoosh: switch to pytest --automake
    applied a55a9b65f4c5... python3-xlrd: switch to pytest --automake
    applied 8667e7db0f48... python3-dnspython: switch to pytest --automake
    applied 76da791a6c65... python3-prettytable: switch to pytest --automake
    applied c576a146a567... python3-ptyprocess: switch to pytest --automake
    applied 10c10c68b776... python3-gunicorn: switch to pytest --automake
    applied 6ad70164f657... python3-pytest-mock: switch to pytest --automake
    applied 7235412ef452... python3-pyroute2: switch to pytest --automake
    applied 2122299d9d3c... python3-smpplib: switch to pytest --automake
    applied 6ec5fc10743d... python3-pyzmq: switch to pytest --automake
    applied 2a628d6898f3... python3-multidict: switch to pytest --automake
    applied d3b75642db2b... python3-geojson: switch to pytest --automake
    applied a32aeade02fe... python3-serpent: switch to pytest --automake
    applied ba1539592a9e... python3-soupsieve: switch to pytest --automake
    applied 3f5af1db9a80... python3-requests-toolbelt: switch to pytest --automake
    applied 22e97ce3f18c... python3-yarl: switch to pytest --automake
    applied 2192056f6729... python3-cbor2: switch to pytest --automake
    applied 441da99311af... python3-ansicolors: switch to pytest --automake
    applied 70c567ad82d9... python3-ipy: switch to pytest --automake
    applied adc660605e0e... python3-sqlparse: switch to pytest --automake
    applied 2690753907d7... python3-precise-runner: switch to pytest --automake
    applied a99a06c9ede8... python3-parse-type: switch to pytest --automake
    applied 0a982fba8122... python3-inflection: switch to pytest --automake
    applied 23de36be41b6... python3-blinker: switch to pytest --automake
    applied f75e988e64a4... python3-service-identity: switch to pytest --automake
    applied 9c52cc5b3d61... python3-cachetools: switch to pytest --automake
    applied 22741a0874fd... python3-simpleeval: switch to pytest --automake
    applied dfbcc2f10dec... python3-appdirs: switch to pytest --automake
    applied ee5a7f0c3849... python3-pillow: switch to pytest --automake
    applied a62b699bcb50... python3-semver: switch to pytest --automake
    applied 848765aba678... python3-platformdirs: switch to pytest --automake
    applied 6610f706f38a... python3-polyline: switch to pytest --automake
    applied a6c2d9fa6186... python3-betamax: switch to pytest --automake
    applied 7537066f8913... python3-pytoml: switch to pytest --automake
    applied 52f5ec0d69b7... python3-pyserial: switch to pytest --automake
    applied 1c9b76323d83... python3-typeguard: switch to pytest --automake
    applied 202a3818ddb8... python3-execnet: switch to pytest --automake
    applied 182f31a182f6... python3-pyyaml-include: switch to pytest --automake
    applied 3b44038a39e6... python3-xxhash: switch to pytest --automake
    applied ee0c034eb9b7... python3-pylint: switch to pytest --automake
    applied a4bd219c75f2... freeradius: Add missing 'radiusd' static group id
    applied 5f81ba9ef3be... ntp: Add missing 'ntp' static group id
    applied 5fdbe368875b... libtinyxml2: fix the homepage URL
    applied 528f27300696... libtinyxml2: allow to build both shared and static libraries

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
