### PR TITLE
subtree update: 95d26fc5b7 -> 9796ee4c26

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -8,13 +8,13 @@ last_revision = aba9250494f62360c1ec8021f81922c005d92b82
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 9f0e5132110cd31112360d754e1203c32cb25ecc
+last_revision = a0237019f5b5c003fd0c6fd4486859214e24be01
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 95a9103f914c3e2665a1ffe7f70533c44cb4f3af
+last_revision = 92a9b7a01245507a347c59997a3e5960b0f75ae9
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -26,5 +26,5 @@ last_revision = 30e755c59204cbd64c3aa12e64ab33041f6f02c0
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 25d60ac6f61cc186b4c5a961554bee583736fd17
+last_revision = 7165c23237d4c2716015bbef397f6f65435cdd67
 


### PR DESCRIPTION
meta-raspberrypi 95a9103f91 -> 92a9b7a012:
    applied 92a9b7a0124... rpi-base: Added missing HiFiBerry
meta-openembedded 9f0e513211 -> a0237019f5:
    applied 2c4ab4a6c2a... openipmi: fix do_configure error when using dash
    applied e569af1ff4b... libkcapi: Update HOMEPAGE url
    applied 4b87fabf121... ristretto: use python3native and depend on glib-2.0-native, python3-packaging-native
    applied fdab9ca9fe1... xfce4-notifyd: use python3native and depend on python3-packaging-native
    applied f8befdbe18c... python3-fastjsonschema: Add missing ptest deps
    applied b7e41815d39... python3-gpiod: Tests rely on configfs support in kernel
    applied f436ca52ba8... python3-pyzmq: Add missing dep on python3-unixadmin for ptests
    applied e8778f71f79... python3-betamax: Upgrade to 0.9.0
    applied 57b9cb2d5d7... libgpiod: Tests rely on configfs support in kernel
    applied d2614ed81e6... iperf3: upgrade 3.15 -> 3.16
    applied b1894042519... grpc: upgrade 1.60.0 -> 1.60.1
    applied 228f10be48b... cryptsetup: upgrade 2.6.1 -> 2.7.0
    applied d61e84a10b2... layer.conf: Add nativesdk-libdevmapper PREFERRED_RPROVIDER
    applied 14e3fc26481... keyutils: Add missing rdep for ptests
    applied 425f999eb93... krb5: upgrade 1.20.2 -> 1.21.2
    applied a326451eb63... postfix: upgrade 3.7.3 -> 3.8.5
    applied 4992816e4fe... openldap: upgrade 2.5.16 -> 2.6.7
    applied 63266a461f4... fuse3: use 4 spaces for indentation
    applied 8b6e7d42973... fuse3: Make kmod as a recommendation instead of rdep for ptests
    applied 40cfae8d4e9... openvpn: upgrade 2.6.7 -> 2.6.9
    applied af838914770... drbd-utils: upgrade 9.22.0 -> 9.27.0
    applied 3c36a915d68... drbd-utils: Disable warnings as errors
    applied 328b8e2bc44... folks: update 0.15.6 -> 0.15.7
    applied 65b8bf69e8f... influxdb: Define GOPROXY
    applied 89fb2e9e7c6... crucible: Define GOPROXY
    applied 2562addd103... syzkaller: Fix build with go 1.21
    applied d1b630342e8... python3-google-auth: upgrade 2.28.0 -> 2.28.1
    applied 428f86671ab... python3-netaddr: upgrade 0.10.1 -> 1.2.1 and add ptest
    applied 1ac098f00d1... nlohmann-json: Upgrade to 3.11.3
    applied ba6b8de1526... ptest-packagelists-meta-python: Move python3-xlrd from PTESTS_PROBLEMS_META_PYTHON to PTESTS_FAST_META_PYTHON
    applied a808e15d6b7... python3-wrapt: add ptest
    applied 92b6825a870... e2tools: Delete unneeded files from ptest package
    applied db58edbed86... googletest: allow for shared libraries
    applied f1c8e5e7344... python3-aiohappyeyeballs: Correct the typo of BBCLASSEXTEND
    applied 2487e65ee38... syslog-ng: upgrade 4.0.1 -> 4.6.0
    applied c904e169dbe... multipath-tools: upgrade 0.9.3 -> 0.9.8
    applied 0d9351e9290... nodejs: upgrade 20.11.0 -> 20.11.1
    applied f88e5b146e0... postgresql: upgrade 15.5 -> 16.2
    applied 092492d68f8... ptest-packagelists-meta-oe: Move libgpiod out of PTESTS_PROBLEMS_META_OE
    applied d789f50c24e... ptest-packagelists-meta-python: Move py3-libgpiod out of PTESTS_PROBLEMS_META_PYTHON
    applied 2a6722d1d9a... drbd-utils: Drop a duplicated line in DESCRIPTION
    applied 0776d3b4e7b... drbd-utils: Fix a udev rule reproducibility
    applied 39e13efc084... python3-freezegun: add recipe and add ptest
    applied f1a49372b3a... python3-dateutil: upgrade 2.8.2 -> 2.9.0
    applied dc8aa867287... mozjs-115: update 115.6.0 -> 115.8.0
    applied 6757155f09a... polkit: update 123 -> 124
    applied e317b01690b... toybox-inittab: Fix serial getty reproducibility
    applied f4eefe2a818... python3-types-python-dateutil: add recipe
    applied a4ee3123dbf... python3-arrow: add ptest, update backend and runtime dependencies
    applied 39b25351230... pgpool2: Upgrade to 4.5.1
    applied 455409badd5... pgpool2: Fix build with postgresql 16+
    applied 4213fb939fb... emacs: Add packageconfig for selinux support
    applied 123c58693ac... signing.bbclass: fix typos
    applied 658408c2a09... glmark2: add upstream patch to not care about stencil config
    applied a0237019f5b... python3-marshmallow: upgrade 3.20.2 -> 3.21.1 and add ptest
poky 25d60ac6f6 -> 7165c23237:
    applied 2387bd6323c... core-image-full-cmdline: add package-management
    applied 9b5c6444f77... no-gplv3: Tweak for packagemangement in core-image-full-cmdline
    applied 9d1a99cf452... qemu: Replace workaround with proper usermode fix for shmat
    applied 9a8fff91488... u-boot: Move UBOOT_INITIAL_ENV back to u-boot.inc
    applied 3299b4942c5... coreutils: backport patch to fix heap overflow in split
    applied 282ade0f4be... mesa,mesa-gl: Fix build when dri3 is not enabled
    applied 9f60a166460... qemu: backport patch for ui/clipboard issue
    applied 2689d8cf22d... bitbake: fetch/git: Avoid clean upon failure
    applied ef88dee4f77... bitbake: prserv/serv: Fix a PID file removal race on prserv stop
    applied 9c730d3bccc... go: rework patch to avoid identation
    applied ed39f516e97... go: bump 1.21.0
    applied fd2e5e0b89d... goarch: disable dynamic linking globally
    applied f92e32957c8... oeqa/gotoolchain: set GOPROXY
    applied d21978d33df... go: upgrade 1.21.0 -> 1.21.5
    applied a13c62b66b7... go: upgrade 1.21.5 -> 1.21.7
    applied a578b5d472f... linux-yocto/cfg/6.6: drop CONFIG_DEBUG_CREDENTIALS
    applied 98c99fa72c0... linux-yocto/6.6: update to v6.6.20
    applied 7f7b2b002e3... linux-yocto/6.6: update CVE exclusions
    applied 486f87659ff... linux-yocto: Enable gpio-sim with ptests
    applied d3b384e8995... gtk+3: update 3.24.38 -> 3.24.41
    applied 7b64530439c... rust: Fix build failure re-appeared on riscv32
    applied 4f1c141ceb2... python3-hypothesis: upgrade 6.98.12 -> 6.98.15
    applied f629e7ef1b8... gdb: Upgrade 14.1 -> 14.2
    applied 2c0d94e4f70... expat: upgrdae 2.6.0 -> 2.6.1
    applied d827eec21c9... python3-cryptography_42.0.5.bb: delete redundant ptest packaging
    applied f15676592bb... bmaptool: now part of Yocto Project
    applied be10de34231... bitbake: utils: remove BB_ENV_PASSTHROUGH from preserved_envvars()
    applied 2f4f72fff2b... Add genericarm64 MACHINE
    applied 22d6c0966bb... rxvt: add rxvt to desktop entry name
    applied d4b3316cf16... xz: correct upstream version check
    applied e9870028b71... image_types.bbclass: fix vfat image names
    applied c28c8e67f70... go: bump 1.22.0
    applied eec5c8778f4... go: Further tweak indentation in patch
    applied 891d30a5d43... go: Drop linkmode with nativesdk/cross-canadian
    applied c60038b7210... libpng: Update SRC_URI to avoid redirects
    applied aaa609ac2b3... ref-manual: classes: add cve status check for oe.qa
    applied aca3afe8278... ref-manual: tasks: do_cleanall: recommend using '-f' instead
    applied 81be53672f3... ref-manual: tasks: do_cleansstate: recommend using '-f' instead for a shared sstate
    applied 9400b992fd4... ref-manual: variables: correct sdk installation default path
    applied 833506169ca... ref-manual: variables: adding multiple groups in GROUPADD_PARAM
    applied c2fd0446ec4... dev-manual: packages: fix capitalization
    applied f9e1cfe9e87... contributor-guide: add notes for tests
    applied dbcb74ef818... manuals: document VIRTUAL-RUNTIME variables
    applied 002a6bbf669... dev-manual: bmaptool: rename
    applied e65840bdd53... python3-sphinxcontrib-jquery: add a recipe and make python3-sphinx-rtd-theme depend on it
    applied d92454308b0... acl: upgrade 2.3.1 -> 2.3.2
    applied a4a5569b787... appstream: upgrade 1.0.0 -> 1.0.2
    applied 51fae36d0cc... boost: upgrade 1.83.0 -> 1.84.0
    applied 35f3279165c... btrfs-tools: upgrade 6.5.3 -> 6.7.1
    applied d1979577501... dnf: upgrade 4.18.2 -> 4.19.0
    applied cbeaf28ada5... diffoscope: upgrade 253 -> 259
    applied 053fe287eae... ell: upgrade 0.62 -> 0.63
    applied 4d80c539be2... elfutils: upgrade 0.189 -> 0.191
    applied 36965634bea... epiphany: upgrade 45.1 -> 45.3
    applied 2f12d809488... gettext: upgrade 0.22.4 -> 0.22.5
    applied c8127fe26b7... glib-2.0: upgrade 2.78.3 -> 2.78.4
    applied 4de1c102522... glib-networking: upgrade 2.78.0 -> 2.78.1
    applied b88cddd1261... kmscube: upgrade to latest revision
    applied 3e180097a9e... libbsd: upgrade 0.11.8 -> 0.12.1
    applied eee41d341d2... libdnf: update 0.72.0 -> 0.73.0
    applied 00013601aad... libpciaccess: upgrade 0.17 -> 0.18
    applied e3b7060e0d8... libpcre2: upgrade 10.42 -> 10.43
    applied c6819eaaa75... librepo: update 1.16.0 -> 1.17.0
    applied 5406ff0bc60... libusb1: upgrade 1.0.26 -> 1.0.27
    applied fae05fe2845... libxml2: upgrade 2.11.5 -> 2.12.5
    applied 6ff5a9ccb62... linux-firmware: upgrade 20231211 -> 20240220
    applied 3a20168e703... librsvg: upgrade 2.56.3 -> 2.57.1
    applied 71c2eb3ac9b... lsof: upgrade 4.98.0 -> 4.99.3
    applied 08cde8263a9... man-pages: upgrade 6.05.01 -> 6.06
    applied 6e342a0c76a... mc: upgrade 4.8.30 -> 4.8.31
    applied 9c029432088... mesa: upgrade 24.0.1 -> 24.0.2
    applied d339047b836... minicom: upgrade 2.8 -> 2.9
    applied 4c7e012637c... nghttp2: upgrade 1.59.0 -> 1.60.0
    applied 304270756eb... orc: upgrade 0.4.37 -> 0.4.38
    applied a0d1d89adb5... puzzles: upgrade to latest revision
    applied 6801330b6cb... piglit: upgrade to latest revision
    applied f2856c715cf... python3-build: upgrade 1.0.3 -> 1.1.1
    applied 316f1fc852a... python3-dtschema: upgrade 2023.7 -> 2024.2
    applied 18c5cba3ad4... python3-jsonschema: upgrade 4.17.3 -> 4.21.1 and add new dependencies
    applied 8fda67f5570... python3-ruamel-yaml: upgrade 0.17.35 -> 0.18.6
    applied 51460be41f5... python3-setuptools: upgrade 69.0.3 -> 69.1.1
    applied 8479b1d2f9c... python3-wcwidth: upgrade 0.2.12 -> 0.2.13
    applied 494b7c73c8a... repo: upgrade 2.41 -> 2.42
    applied 5cb15230617... shaderc: update 2023.7 -> 2023.8
    applied bd0c5a7781d... systemd: upgrade 255.1 -> 255.4
    applied c1cdc892d71... ttyrun: upgrade 2.30.0 -> 2.31.0
    applied ec8a8ef1cf6... taglib: upgrade 1.13.1 -> 2.0 and add utfcpp recipe to support that
    applied 1d9d6387b01... update-rc.d: upgrade to latest revision
    applied 16aa12c8da9... vala: upgrade 0.56.13 -> 0.56.15
    applied c9be277fb3b... vulkan: upgrade 1.3.268.0 -> 1.3.275.0
    applied 02201e986d4... webkitgtk: upgrade 2.42.2 -> 2.42.5
    applied b9e9693cb08... qemurunner.py: Fix error on calls to run_monitor
    applied f4665afc3c4... screenshot-tests: Add initial screenshot test png files for core-image-sato
    applied b49d42ce90f... oeqa/runtime/login: Proof of concept for screenshot testcases
    applied 4d161405d5f... oeqa/runtime/login: Various code improvements and fixes
    applied 96af410e8e3... oeqa/runtime/login: Mask out the mouse panel icon for now
    applied 59c7b5e7062... oeqa/runtime/login: Exclude qemuriscv64
    applied f6235fef62a... oeqa/runtime/login: Add screenshot sample logic/timeout/dbus-wait
    applied 0bd3234676f... oeqa/runtime/login: Fix dbus-wait timeout and loop conditional
    applied 2b5903f5110... sstatetests.py: Add testing for correct sstate permissions
    applied 329bd0cfa92... valgrind: skip intermittently failing ptests
    applied 66cf8644c29... rxvt-unicode: Fix installing of terminfo
    applied da9db878a15... systemd: fix dead link /var/log/README
    applied 54f32640a0a... systemd: use RDEPENDS for systemd-vconsole-setup
    applied bf6591b935e... systemd: remove systemd-bus-proxy settings
    applied 7165c23237d... go: filter out build specific path from the linker flags

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
