### PR TITLE
subtree update: c4d370ff5c -> fddc31c83c

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = aba9250494f62360c1ec8021f81922c005d92b82
+last_revision = d9e18ce7920fd4b6216fbda6c7938450aa3b45b7
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = a0237019f5b5c003fd0c6fd4486859214e24be01
+last_revision = a6bcdca5b4681906b00e12f6bc4af465c85bad9f
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 92a9b7a01245507a347c59997a3e5960b0f75ae9
+last_revision = d072cc8a48571a4af40a937f98e173b5c9468c4f
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = 30e755c59204cbd64c3aa12e64ab33041f6f02c0
+last_revision = 283a773f24cedacb45def943a455bc3607f8a7a1
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 7165c23237d4c2716015bbef397f6f65435cdd67
+last_revision = 110ee701b33600f14e40544bf9354774cd85c5ce
 

--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = d9e18ce7920fd4b6216fbda6c7938450aa3b45b7
+last_revision = 17df9c4ebc6614da641dcb9e85246171d940098d
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = a6bcdca5b4681906b00e12f6bc4af465c85bad9f
+last_revision = 4958bfe01324f0bfcc2414fc694e27d3c4111f53
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = d072cc8a48571a4af40a937f98e173b5c9468c4f
+last_revision = 1879cb831f4ea3e532cb5ce9fa0f32be917e8fa3
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = 283a773f24cedacb45def943a455bc3607f8a7a1
+last_revision = d1522af21da8d799a8f397aef6359b5ed4dc07fe
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = 110ee701b33600f14e40544bf9354774cd85c5ce
+last_revision = 5950c63d54228f15a973d8d8c843b0dc9987ab7f
 


### PR DESCRIPTION
meta-security 30e755c592 -> 283a773f24:
    applied 4eab875b339... meta-security: Drop ${PYTHON_PN}
    applied f9f0aa774b1... docs: dm-verity.txt: Fix a typo
    applied 7b951e39009... dm-verity: Adjust the image names according to the oe-core change
    applied d80cd2ba6a3... dm-verity: Set the IMAGE_FSTYPES correctly when dm-verity is enabled
    applied 0f4b8ec2a7c... arpwatch: fix misspelling of PACKAGECONFIG
    applied bb9321264a2... aprwatch: Add path for sendmail
    applied 60021acffb2... openscap: update to tip to fix new build issue.
    applied 40ddb9e5ed7... dm-verity-image-initramfs: Set IMAGE_NAME_SUFFIX to empty
    applied f4ef325fc31... Check for usrmerge before removing /usr/lib
    applied 4ee2703298e... arpwatch: install man8 dir
    applied 2f89aa7e416... layer.conf: Update for the scarthgap release series
    applied 283a773f24c... python3-pyinotify: Make asyncore support optional for Python 3
poky 7165c23237 -> 110ee701b3:
    applied 47c201da561... poky: Update to prepare for scarthgap release
    applied e1858360af1... genericarm64.wks: reorder partitions
    applied 4b42a93edf3... genericarm64: clean up kernel modules and firmware
    applied 045eb591308... bmaptool: Add bmap-tools runtime alias for compatibility
    skipped e8384ba2fa3... systemd: Check for directory before chmod'ing it
    applied ca829f14e0b... go.bbclass: set GOPROXY
    applied 125771c16f9... kernel-fitImage: only include valid compatible line
    applied b5624ee5643... openssh: Add a workaround for ICE on powerpc64le
    applied 6243d7b8ce6... cve-update-nvd2-native: Fix typo in comment
    applied 19f27037b2b... cve-update-nvd2-native: Add an age threshold for incremental update
    applied 64a54c9c399... cve-update-nvd2-native: Remove duplicated CVE_CHECK_DB_FILE definition
    applied 50e17197c6f... cve-update-nvd2-native: nvd_request_next: Improve comment
    applied c698cf6723f... cve-update-nvd2-native: Fix CVE configuration update
    applied 789b10030c6... cve-update-nvd2-native: Remove rejected CVE from database
    applied a41c320b001... layer.conf: Prepare for release, drop nanbield LAYERSERIES
    applied 4293466bf68... expat: Upgrade 2.6.1 -> 2.6.2
    applied 3dc62ba4a8b... rust: reproducibility issue fix with v1.75
    applied 04d74605299... mesa: fix opencl-spirv build
    applied 0b122f63379... linux-firmware: add support for deduplicating the firmware
    applied e25101c044d... linux-firmware: set LICENSE field for -liquidui and -mellanox
    applied 83f7d147e53... linux-firmware: remove pointless linux-firmware-gplv2-license package
    applied a490243e885... vala: merge bb and inc files
    applied 7f4aa8e6a31... vala: fix for gtk4 prior to 4.14
    applied 421083c46c9... git: git-replacement-native: depend on ca-certificate
    applied 8ffe194baa7... llvm: Update to 18.1.1 release
    applied 9d4c2be5646... elfutils: Fix build break with clang
    applied af911135e4c... glibc: Update to tip of 2.39 branch
    applied ab730c56616... linux-firmware: Move Intel 9260 modules firmware.
    applied 2894a574db6... meson: correct upstream version check (exclude pre-releases)
    applied 2db6df6f2e4... cargo-c-native: convert from git fetcher to crate fetcher
    applied 8139216000e... cargo-c-native: update 0.9.18 -> 0.9.30
    applied 276332d289f... lttng-tools: skip kernel tests if no kernel modules present
    applied 88eaffee1e1... man-pages: use env from coreutils-native
    applied aec64781fe8... kernel: Fix check_oldest_kernel
    applied 893a8bacc5b... libtirpc: drop redundant PACKAGECONFIG
    applied 20035573145... gcc: Oe-selftest failure analysis - fix for tcl errors
    applied 4fd93a7be40... pam: Fix build with musl
    applied 1e4de6edc6f... go: Upgrade 1.22.0 -> 1.22.1
    applied 08081135175... ref-manual: classes: update description of class 'image_types'
    applied e987c5151c3... manuals: add initial stylechecks with Vale
    applied 063b0cf8f99... profile-manual: usage.rst: formatting fixes
    applied 3b86df94f7a... manuals: use "manual page(s)"
    applied 2b66b2f8eba... profile-manual: usage.rst: fix reference to bug report
    applied df44348f0b5... documentation: Makefile: remove releases.rst in "make clean"
    applied ddd8f69db96... migration-guides: draft notes for upcoming release 5.0
    applied 13d1ee8cb41... migration-guides: add release notes for 4.0.17
    applied 8a8040b37e0... contributor-guide: be more specific about meta-* trees
    applied f6584a38ae0... manuals: add initial stylechecks with Vale
    applied d255faa35e5... profile-manual: usage.rst: further style improvements
    applied 98fb300f401... ref-manual: add documentation of the variable SPDX_NAMESPACE_PREFIX
    applied b685c76b682... sdk-manual: correctly describe separate build-sysroots tasks in direct sdk workflows
    applied bc06390947e... dev/ref-manual: document conf-summary.txt together with conf-notes.txt
    applied 27e72a5f13a... dev-manual: improve descriptions of 'bitbake -S printdiff'
    applied 54441215bda... bash/flex: Ensure BUILD_FLAGS doesn't leak onto target
    applied b739fa5f4d9... uninative: Add pthread linking workaround
    applied 264a3f429aa... curl: improve run-ptest
    applied b2191bb7a70... curl: increase test timeouts
    applied 78e48090b2c... gstreamer1.0: improve test reliability
    applied 7588fe77a19... libsoup: enable vapi support
    applied 7d530aa4170... shadow: fix copydir operation with 'pseudo'
    applied b4be67b5f7c... elfutils: fix unused variable BUFFER_SIZE
    applied 37d2ba9adbe... wayland: fix upstream version check by asking gitlab directly
    applied 2d606350c70... python3: correct upstream version check
    applied f451612ca2b... linux-yocto/6.6: cfg: generic arm64
    applied f09310d7f53... linux-yocto/6.6: cfg: riscv XHCI
    applied f2c46dea04b... linux-yocto/6.6: update to v6.6.21
    applied b352ffe7706... linux-yocto/6.6: update CVE exclusions (6.6.21)
    applied e686282da89... linux-yocto/6.6: cfg: drop unsettable options
    applied f405c9b560c... linux-yocto/6.6: drm/tilcdc: Set preferred depth
    applied f3ffd35e333... linux-yocto/6.6: update to v6.6.22
    applied a8c6271be20... linux-yocto/6.6: update CVE exclusions (6.6.22)
    applied 38fa6d08d29... piglit: Switch to upstreamed patch for musl fix
    applied 181f8d101bc... mesa: enable imagination powervr support
    applied 160dce550c8... lttng-modules: fix v6.8+ build
    applied e83129f4a3a... poky-altcfg: Default to ipk packaging
    applied 5e69d4ba0fb... linux-yocto: put COMPATIBLE_MACHINE first
    applied 20c1d917c6d... linux-yocto: implicitly track oe-core's kernel version for genericarm64
    applied 94f99434eff... yocto-bsps: update to v6.6.21
    applied b9497332dd6... qemuriscv: Fix kbd and mouse emulation for qemuriscv64
    applied ab02ac1b277... python3-manifest: Sync RDEPENDS with latest version
    applied 212be697153... ltp: fix missing connectors tests in scenario_groups/default
    applied 5d826cd425f... gsettings-desktop-schemas: update 45.0 -> 46.0
    applied e420d29267b... libadwaita: upgrade 1.4.3 -> 1.4.4
    applied 47ec5094768... libadwaita: update 1.4.4 -> 1.5.0
    applied d61921cc1e2... llvm: Upgrade to 18.1.2 bugfix release
    applied 1b15f9e78ae... gtk4: update 4.12.5 -> 4.14.1
    applied 98d09d41fa1... bitbake: bitbake: improve descriptions of '-S printdiff'
    applied 0acdb81ca62... bitbake: bitbake-worker: Fix bug where umask 0 was not being applied to a task
    applied ecb1248914c... bitbake: bitbake-worker: allow '=' in environment variable values
    applied 2eeef2800b3... bitbake: bitbake: fetch2/git: Escape parentheses in git src name
    applied adb0ea98d1f... bitbake: lib/bb: support NO_COLOR
    applied e20ee877ed4... bitbake: fetch2: handle URIs with single-valued query parameters
    applied 3a977928209... bitbake: fetch2: Fix misleading "no output" msg
    applied 9504df41f9e... bitbake: utils: better estimate number of available cpus
    applied 64057e6b153... bitbake: bitbake-worker: Fix silent hang issue caused by unexpected stdout content
    applied 825055e83ea... bitbake: fetch2/git: Install Git LFS in local repository config
    applied 0291c2c1314... python3_pip517: just count wheels in the directory, not subdirectories
    applied f111c2a1202... python-*: don't set PYPI_ARCHIVE_NAME and S when PYPI_PACKAGE is sufficient
    applied 62c184ed614... gcc: Oe-selftest failure analysis - fix for vect-simd test failures
    applied 084fe2241bf... toolchain-shar-relocate.sh: Add check for missing command 'file'
    applied 3fa85ab34ef... bmaptool: update to latest
    applied 6b70b8b646b... systemd: enable mac based names in NamePolicy
    applied 9d1df0596f6... tcl: improve run-ptest
    applied b3b611a5e50... tcl: skip I/O channel 46.1
    applied 84cb5d2568d... sstatesig: Set hash server credentials from bitbake variables
    applied f9b691150bf... shadow: don't install libattr.so.* when xattr not in DISTRO_FEATURES
    applied 8580c232847... u-boot: fix externalsrc not triggering do_configure on defconfig changes
    applied d616929413a... linux-yocto/6.6: cfg: genericarm64 platform/peripheral support
    applied 978206fed48... bitbake: siggen: Add support for hashserve credentials
    applied 21c9a9f8146... genericarm64: add qemuboot configuration
    applied daa6afead84... classes/qemuboot: add depends on qemu-system-native and qemu-helper-native
    applied 81567510fd9... glibc: Repace aarch configure patch fix with a backport
    applied 7c3f956a0a8... wic: bootimg-partition allow to set var to get boot files
    applied 3b69367bc22... kernel-module-split.bbclass: enhance objcopy command call for kernel compilation with llvm
    applied df60c6d3eea... sstatesig: Warn on bad .netrc
    applied f2ff622a4c8... bitbake: bitbake-hashclient: Warn on bad .netrc
    applied 07d62690b0c... README.hardware.md: fix Markdown formatting
    applied ae7056844aa... README.hardware.md: add section on genericarm64 on qemu
    applied 854b0ee4bd8... coreutils: drop obsolete liberror-perl RDEPENDS
    applied 863a7dd585c... liberror-perl: move to meta-perl
    applied 91d11b3ad86... glib-2.0: skip a timing sensitive ptest
    applied d1622b87f8c... selftest/sstatetests: run CDN check twice, ignoring errors the first time
    applied 47389891e59... linux-yocto/6.6: cfg: genericarm64 configuration updates
    applied fce4a47d784... linux-yocto/6.6: nftables: ptest and cleanup tweaks
    applied f0034f0d2bb... linux-yocto/6.6: update to v6.6.23
    applied 43334573310... linux-yocto/6.6: update CVE exclusions (6.6.23)
    applied 3c7e103af4d... util-linux: Add missing MIT license
    applied 4e6a20efa9d... util-linux: Add fcntl-lock
    applied 7c916d8f1bf... run-postinsts: Add workaround for locking deadlock issue
    applied b84ae2ad79e... gstreamer: upgrade 1.22.10 -> 1.22.11
    applied 4a8b005afc5... openssl: fix crash on aarch64 if BTI is enabled but no Crypto instructions
    applied b7df5bd45d6... valgrind: Backport fixes from 3.22 branch
    applied 861a703c1af... tcl: Forward port skip logic for musl ptests
    applied 9b839a835cc... bblayers/makesetup.py: Move git utility functions to oe.buildcfg module
    applied 319353cd9d5... dnf: fix Exception handling for class ProcessLock
    applied 356a4893450... cml1: remove needless check for write_taint attribute
    applied 04eb94b84e9... cml1: prompt location of updated .config after do_menuconfig()
    applied 7d2ea09deb9... populate_sdk_ext.bbclass: only overwirte lsb string if uninative is used
    applied d5d10db4299... curl: fix quoting when disabling flaky tests
    applied 135c4f7b560... readline: Apply patches from readline-8.2-patches
    applied c152a1e25c4... systemd: disable mdns feature in resolved for zeroconf
    applied 8203f61959d... mesa: Drop LLVM-17 patch
    applied f5e084ede60... utils: enhance readelf command call with llvm
    applied 66f2f710e63... oe/package: enhance objdump command call with llvm
    applied 30d88a20432... oeqa/sstatetests: Fix race issue
    applied fa6c4f014a5... ovmf: set CVE_PRODUCT and CVE_VERSION
    applied e96918f49ec... bash: improve reproducibility
    applied cabeed4e6d3... curl: improve reproducibility
    applied e6da241f294... gmp: improve reproducibility
    applied f938563eeab... lttng-tools: fix rotation-destroy-flush test fails if no kernel module present
    applied 5b486cd1dc0... util-linux: Set the license for util-linux-fcntl-lock to MIT
    applied 18855888073... gnutls: upgrade 3.8.3 -> 3.8.4
    applied b041bd9eaba... webkitgtk: update 2.42.5 -> 2.44.0
    applied 8d27d8ff7cc... glibc: Skip 2 qemu tests that can hang in oe-selftest
    applied f9ed8b9fa1b... gtk+3: disable wayland without opengl
    applied 11651df0f62... epiphany: update 45.3 -> 46.0
    applied 905b41d6bf0... libseccomp: Add back in PTESTS_SLOW list
    applied 0cd45e051c7... image-live.bbclass: Adjust the default value for INITRD_LIVE
    applied f785a323aea... autotools: update link in comment for cross compiling
    applied 14605487643... linux-firmware: update to 20240312
    applied 61b7acdb762... pixman: explicitly disable openmp in native builds
    applied 0c9d83138e2... oeqa/selftest/overlayfs: test read-only rootfs
    applied 5a433a80f37... binutils: gprofng - change use of bignum to use of bignint
    applied 0447fc142b0... linux-yocto-dev: bump to v6.9
    applied acdb1bb14e1... lttng-modules: update to v2.13.12
    applied 38f6f3a0664... perf: Fix QA error due to most recent kernel
    applied ad81041a336... perf: fix TMPDIR contamination for recent mainline kernels
    applied 8969055428f... go: keep the patches in order
    applied 797c243eccb... go: upgrade 1.22.1 -> 1.22.2
    applied ab6d3e3d645... oeqa/selftest/devtool: fix test_devtool_add_git_style2
    applied 110ee701b33... sstatesig: fix netrc.NetrcParseError exception
meta-raspberrypi 92a9b7a012 -> d072cc8a48:
    applied e9a1940bab9... linux-raspberrypi: Add recipe for 6.6 LTS kernel
    applied ba342d2a9e4... bluez-firmware-rpidistro: Upgrade to 1.2-9+rpt3 release
    applied a62c7c2ca6b... linux-firmware-rpidistro: Upgrade to bookworm/20230625-2+rpt2
    applied 90d4e6568a5... raspberrypi-firmware: Fetch using git URI
    applied 6a7aac79ce1... rpi-base: Add missing broadcom/ prefix to find DTB files
    applied 1cf3dd5e5ef... rpi-default-versions: Switch default kernel to 6.6
    applied d88e625cf2d... userland: fix installed-vs-shipped in multilib builds
    applied e8d4ac24a41... linux-raspberrypi_6.6: Bump to 6.6.22
    applied bb8d5f7e9b8... rpi-bootfiles: Resort to github APIs for tarballs
    applied ec06e94f2a4... raspberrypi-firmware: Revert to debian archive
    applied d072cc8a485... rpi-base: Add hifiberry-dacplusadc overlay
meta-arm aba9250494 -> d9e18ce792:
    skipped a01f2721493... optee-ftpm: fix EARLY_TA_PATHS passed to optee-os
    applied 697fcf43948... arm/trusted-firmware-a: fix mbedTLS version
    applied f6f616c38d2... arm-bsp/trusted-firmware-a: Upgrade Corstone1000 to TF-A v2.10
    applied 6e2a547482f... kas: Corstone-1000 kas files updated
    applied 9ea97cf4f5c... bsp: Corstone-1000 userguide updates
    applied e867b0aa6a8... arm arm-bsp: enable patch-status warnings
    applied 2bfbb33518f... README: Add information about release process and mailing list
    applied 74ac722826d... arm/linux-yocto: remove unreferenced patch
    applied a8f47e9504a... arm-bsp/trusted-firmware-m: corstone1000: update to 2.0
    applied de57703654d... arm-bsp/trusted-services: corstone1000: Client Id adjustments after TF-M 2.0
    applied ab6e5f47889... arm/trusted-firmware-m: Change GNU Arm compiler version for TF-M 2.0
    applied fb1a85a43c6... arm-bsp/u-boot: corstone1000: fix SMCCC_ARCH_FEATURES detection in the PSCI driver
    applied 0792a314f62... arm-bsp/trusted-firmware-a: corstone1000: remove SMCCC_ARCH_FEATURES discovery workaround
    applied 67901eb5cbb... arm/optee: disable clang due to breakage
    applied 1c35b69b6e0... arm-bsp/n1sdp: Update scp-firmware version
    applied 299003f7fcf... arm-bsp/n1sdp: Update EDK2 version
    applied c93a1459daf... Add SECURITY.md
    applied 6cd998d411d... arm/trusted-services: Add recipe for block storage service
    applied a19c7d7b762... arm-bsp/tf-a-tests: remove corstone1000 intermediate SHA
    applied 59b79d5e92a... arm-bsp/tfa-tests: move n1sdp patch to platform directory
    applied da97414dfbc... CI: update kas to 4.3.1
    applied a77c2859d18... arm/edk2: update to 202402
    applied 6bc5f4ff2d2... arm/trusted-firmware-a: update to 2.10.2
    applied 362e7d6f050... arm/sbsa-acs: update to 7.1.4
    applied 5705ede03d7... arm/scp-firmware: update to v2.14.0
    applied 81e3864bee2... arm-toolchain/gcc-arm-none-eabi: remove 11.2
    applied 0aeec5472ce... CI: reduce coverage of dev kernel
    applied 3877284730d... arm/rmm: Add bitbake, include and patch file for RMM firmware
    applied d36afba0cad... arm/sbsa-acs: remove unreferenced patch
    applied f9bc290fc96... arm-toolchain: correct UPSTREAM_CHECK
    applied c652a09b32d... Revert "arm/rmm: Add bitbake, include and patch file for RMM firmware"
    applied 2271e337667... CI: ignore netrc warnings caused by Kas
    applied b5f2a793ea3... arm-bsp/trusted-firmware-a: n1sdp: update to 2.10
    applied 7163b472ab8... arm/sbsa-acs: use UPSTREAM_CHECK_URI for version checking
    applied 8d308aac029... arm: use UPSTREAM_CHECK_COMMITS for git versioned recipes
    applied d9e18ce7920... arm-bsp/corstone1000: add documentation disclaimer
meta-openembedded a0237019f5 -> a6bcdca5b4:
    applied b2f7f2b3e45... tracker: remove unused patch
    applied 85d566ff91e... openal-soft: remove unused patches
    applied a9ddcbb2d1c... libio-pty-perl: remove unsed patch
    applied ceba2be18da... opengl-es-cts: remove unused patch
    applied e737827b74c... emacs: remove unused patch
    applied db2af2d23ae... webkitgtk3: remove unused patch
    applied 9929ca5220d... python3-eth-utils: remove unused patches
    applied 6bf3bc30c5c... bats: upgrade 1.10.0 -> 1.11.0
    applied b618b07daab... c-ares: upgrade 1.26.0 -> 1.27.0
    applied ed39b75bc8c... ctags: upgrade 6.1.20240114.0 -> 6.1.20240225.0
    applied 1c3a4f9b562... dbus-cxx: upgrade 2.5.0 -> 2.5.1
    applied bb0f7063666... ddrescue: upgrade 1.27 -> 1.28
    applied dd82a3ab81b... fetchmail: upgrade 6.4.37 -> 6.4.38
    applied 9111c760d9b... libtalloc: upgrade 2.4.1 -> 2.4.2
    applied 3feaaf5424b... libtdb: upgrade 1.4.9 -> 1.4.10
    applied f80a69be04a... neatvnc: upgrade 0.7.2 -> 0.8.0
    applied a3268284246... ostree: upgrade 2024.3 -> 2024.4
    applied 59ccd2e91af... python3-astroid: upgrade 3.0.3 -> 3.1.0
    applied b88e83db402... python3-cbor2: upgrade 5.6.1 -> 5.6.2
    applied c5bf95969e8... python3-dnspython: upgrade 2.6.0 -> 2.6.1
    applied d8198ead10d... python3-eventlet: upgrade 0.35.1 -> 0.35.2
    applied 890e6b69624... python3-gcovr: upgrade 7.0 -> 7.2
    applied 149b4f4cfb3... python3-google-api-core: upgrade 2.16.2 -> 2.17.1
    applied 7bb7f5a6db4... python3-google-api-python-client: upgrade 2.118.0 -> 2.120.0
    applied 7fc8087c653... python3-grpcio(-tools): upgrade 1.60.1 -> 1.62.0
    applied 9802aebdf53... python3-ipython: upgrade 8.21.0 -> 8.22.1
    applied a8b7532a3d4... python3-pdm: upgrade 2.12.3 -> 2.12.4
    applied 84c014f98fd... python3-pymisp: upgrade 2.4.185 -> 2.4.186
    applied 9e1a127e411... python3-scrypt: upgrade 0.8.20 -> 0.8.24
    applied c3c6649eb70... python3-sentry-sdk: upgrade 1.40.4 -> 1.40.6
    applied 698c93690b7... smarty: upgrade 4.3.4 -> 4.4.1
    applied d49f1069c57... stunnel: upgrade 5.69 -> 5.72
    applied 29a287046e8... netplan: upgrade 0.106 -> 1.0
    applied 442b986b87a... python3-icecream: add recipe
    applied 3241575a20f... python3-invoke: add recipe
    applied 5c554c9b8cb... abseil-cpp: A little clean-up
    applied 32eefcf1ca9... abseil-cpp: Split so-files into separate packages
    applied f240c5cecf3... networkmanager: 1.44.0 -> 1.46.0
    applied 297c8b2031e... postfix: upgrade 3.8.5 -> 3.8.6
    applied be21057c22d... gosu: Upgrade to 1.17
    applied be06d51d613... googletest: Pass -fPIC to CFLAGS
    applied bf30c08dd56... re2: Upgrade 2023.03.01 -> 2024.03.01
    applied dafd02adc5a... squid: Upgrade to 6.8
    applied 05afab094d4... nss: Upgrade 3.74 -> 3.98
    applied 0178f526366... net-snmp: upgrade 5.9.3 -> 5.9.4
    applied 9c6e4d467c7... mozjs-115: fix reproducibility issue
    applied 8cb9b358393... python3-traitlets: add ptest and update runtime dependencies
    applied 0a8e1c4ec29... python3-google-auth-oauthlib: add ptest
    applied 9dcc8598072... libnice: Disable the examples and the tests
    applied a30f1158d95... googletest: allow for shared libraries
    applied cbb570cdd96... libosinfo: Fix build with libxml2 v2.12
    applied 18e019ee229... python3-tomli-w: added recipe which is also include ptest
    applied 6b0da50505e... xmlstarlet: Fix build with API breakage in libxml2 2.12
    applied b5ea420d4e8... mariadb: Fix build with libxml2 2.12 ABI changes
    applied a60e2b87ca3... libmusicbrainz: Update to tip of trunk
    applied d8511c2432c... gnome-commander: Fix build with taglib 2.0
    applied 903c8e58ed2... abseil-cpp: upgrade 20230802.1 -> 20240116.1
    applied fe52d23b15e... gnome-online-accounts: Fix build with libxml2 2.12
    applied 22c255b2e9b... vlc: Upgrade to 3.0.20
    applied 8cf55e279fd... tcprelay: fix a minor cross compilation do_configure issue
    applied a5fd08e401c... python3-pytest-localserver: added recipe which is also include ptest
    applied 8a69bf4e36f... python3-responses: add recipe
    applied dd0a156fa8f... python3-google-auth: add ptest and update runtime dependencies
    applied 9fedf2fab34... webp-pixbuf-loader: update 0.2.5 -> 0.2.7
    applied 1bafebf636f... yaffs2-utils: Upgrade to 20221209
    applied 7f50e80c19d... xfsprogs: 6.5.0 -> 6.6.0
    applied 55a6d96e6ae... gnulib: 2018-12-18 -> 202401
    applied 978395023dc... netcf: Fix build with latest gnulib
    applied 2da0ae3cb2c... thin-provisioning-tools: 1.0.9 -> 1.0.12
    applied fdfd5109923... remove obsolete PIP_INSTALL_PACKAGE and PIP_INSTALL_DIST_PATH
    applied 29e772087c9... php: Upgrade to 8.2.16
    applied b956b89fcde... vlc: Fix build on 32bit x86
    applied 109de389d28... gnome-control-center: fix reproducibility issue
    applied 7e48a3f525b... gnome-disk-utility: fix reproducibility issue
    applied 88ef09f8795... gnome-settings-daemon: fix reproducibility issue
    applied b443dacec01... gnome-terminal: fix reproducibility issue
    applied 578071e46fb... libvncserver: fix reproducibility issue
    applied 75d5263f306... python3-a2wsgi: added recipe which is also include ptest
    applied 8c211762655... python3-httptools: added recipe which is also include ptest
    applied 5eb1fa3418e... python3-wsproto: Add recipe
    applied 58224a65f28... fmt: remove unnecessary "inherit ptest" directive
    applied 274879eadb7... editorconfig-core-c: fix reproducibility issue
    applied 2669bca4790... crossguid: fix reproducibility issue
    applied 3e6f301fb5b... waylandpp: fix reproducibility issue
    applied fc34acf93fa... ser2net: add a systemd service file
    applied 4aa939bfe9c... cryptsetup: upgrade 2.7.0 -> 2.7.1
    applied fec5747a4c5... samba: upgrade 4.19.4 -> 4.19.5
    applied b8ccd50e0ea... polkit: remove unneeded workaround
    applied e800784b5d4... libgpiod: update to v2.1.1
    applied a44ba09d6d8... gtk-vnc: fix reproducibility issue
    applied 0182848ca47... abseil-cpp: A little clean-up
    applied dd6421e65eb... abseil-cpp: Split so-files into separate packages
    applied 5f504174983... libtinyxml2: Extend for nativesdk
    applied 788a2ea4a8a... python3-pylint: Update to 3.1.0
    applied e4865f3ee0d... lvgl: Drop dialog-lvgl
    applied f7fedd15637... lvgl: Upgrade to LVGL 9 series
    applied 383efa47d3c... lvgl: Rename lv-drivers.inc to lv-conf.inc
    applied 2e69edc17a2... lvgl: Add SDL2 fullscreen mode configuration option
    applied 1f075a9a285... lvgl: Configure assertions based on DEBUG_BUILD
    applied 87e19a8c3d6... lvgl: Default to XRGB8888 DRM framebuffer
    applied 2054fda6d1d... lvgl: Build shared library
    applied 0f2a4991001... lvgl: Replace sed patching with real patches
    applied 59b8f744757... lvgl: Fix dev-elf build QA
    applied 63250c3ba81... dnf-plugin-tui: upgrade 1.3 -> 1.4
    applied 0be30bee7a7... jwt-cpp: fix cmake file install path
    applied 0c428fac857... python3-pylint: Fix ptest failures
    applied 8186418f5b9... layer.conf: Update for the scarthgap release series
    applied 4b09b8f12fb... lvgl: Generate proper shared libraries with version suffix
    applied 8aec805ac4b... postgresql: fix a runtime error
    applied e49860ee219... unionfs-fuse, dropwatch, postgresql, yasm, multipath-tools, python3-pybind11: add missing Upstream-Status
    applied e481e6bde64... sngrep: new recipe for ncurses SIP Messages flow viewer
    applied e722be5facd... recipes: Drop remaining PR values from recipes
    applied d52c3b94068... python3-pydantic-core: just set PYPI_PACKAGE
    applied ee2001b3037... imagemagick/lcms/fftw: Allow nativesdk versions to exist
    applied 2e3a4b155cd... buildtools-imagemagick: Add new recipe
    applied 77817d1c16d... dietsplash: Update and fix build with musl
    applied 704e3e0a3d2... frr: Upgrade to latest on 9.1 stable
    applied 3f08151bf46... frr: Fix build on newer musl
    applied b7d577d8d3e... libmbim: Revert back to the latest stable 1.30.0
    applied 538b03a3ffa... libqmi: Revert back to the latest stable 1.34.0
    applied 6a2b29e98d7... spandsp: new telephony DSP library
    applied 910614b4b30... lvgl: fix typo in lv-conf.inc
    applied 9e136f00431... lvgl: install lv_conf.h
    applied 531407398ec... lvgl: remove useless FILES include
    applied 5ae9986261f... lvgl: cleanup sed instructions in lv-conf.inc
    applied a898fb981e2... lvgl: add more variables to lv-conf.inc
    applied a35c8581bcf... lvgl: fix libdrm include
    applied 03bfdf5aa68... lvgl: lv-conf.inc: generalize sed instructions
    applied a8310f7f31a... layer.conf: Prepare for release, drop nanbield LAYERSERIES
    applied c91ee174431... pipewire: update 1.0.3 -> 1.0.4
    applied 18eeb70db21... mutter: remove zenity from rdepends
    applied 14cadee2f80... mutter: update 45.4 -> 46.0
    applied 8c3591ae108... gnome-shell: update 45.4 -> 46.0
    applied 92eb65c1113... gnome-settings-daemon: update 45.0 -> 46.0
    applied 0fad89abf86... gnome-software: update 45.3 -> 46.0
    applied 1e2b75420a8... evince: update 45.0 -> 46.0
    applied 621bffd4750... gnome-online-accounts: update 3.48.0 -> 3.50.0
    applied c6d3bed4981... evolution-data-server: build with webkitgtk4
    applied 039f2dfdf72... folks: update 0.15.7 -> 0.15.8
    applied 816f4cbbda7... geoclue: enable demo agent
    applied 03ee9d668f5... gnome-control-center: update 45.3 -> 46.0
    applied f9020cdec0f... xdg-desktop-portal-gnome: update 45.1 -> 46.0
    applied 4e9df16acb5... ostree: Upgrade 2024.4 -> 2024.5
    applied c9c51b1bfad... lvgl: make libdrm include conditional
    applied a0ae7874559... lvgl: cleanup sed expression
    applied 30a5a3bb26c... bluez-tools: New recipe for bluez5 tools
    applied 9463b32b496... civetweb: remove buildpaths from civetweb-targets.cmake
    applied 572fca2f79f... tracker: update 3.6.0 -> 3.7.0
    applied e3842d84c15... tracker-miners: update 3.6.2 -> 3.7.0
    applied ff818f90703... boost-sml: upgrade 1.1.9 -> 1.1.11
    applied ca85da26f9c... ctags: upgrade 6.1.20240225.0 -> 6.1.20240310.0
    applied cbe25ec1ae9... dialog: upgrade 1.3-20240101 -> 1.3-20240307
    applied 713070971dc... flatbuffers: upgrade 23.5.26 -> 24.3.7
    applied 46ccb1d4833... gjs: upgrade 1.78.4 -> 1.80.0
    applied 2368613e6aa... hwdata: upgrade 0.379 -> 0.380
    applied 5d512e0ac34... iceauth: upgrade 1.0.9 -> 1.0.10
    applied b3581d8d911... libdnet: upgrade 1.17.0 -> 1.18.0
    applied 58fe510020d... libopus: upgrade 1.4 -> 1.5.1
    applied 8148bc7498c... libreport: upgrade 2.17.11 -> 2.17.15
    applied 10ad5afff75... libxaw: upgrade 1.0.15 -> 1.0.16
    applied 7c92b007458... mcelog: upgrade 196 -> 197
    applied 0bfe8ae4329... networkd-dispatcher: upgrade 2.1 -> 2.2.4
    applied 554ea0aeac8... openlldp: upgrade 1.1.0 -> 1.1.1
    applied fc996b19289... opensc: upgrade 0.24.0 -> 0.25.0
    applied 3de9dd7c49a... pcsc-lite: upgrade 2.0.1 -> 2.0.3
    applied f9decf0f533... python3-a2wsgi: upgrade 1.10.2 -> 1.10.4
    applied ef73b4620b1... python3-apiflask: upgrade 2.1.0 -> 2.1.1
    applied d1a64f48ecb... python3-argcomplete: upgrade 3.2.2 -> 3.2.3
    applied 99b4f570ff7... python3-bandit: upgrade 1.7.7 -> 1.7.8
    applied a6439a2179f... python3-blivet: upgrade 3.8.2 -> 3.9.1
    applied 05c68382cb4... python3-blivetgui: upgrade 2.4.2 -> 2.5.0
    applied 9aededce566... python3-django: upgrade 5.0.2 -> 5.0.3
    applied 88c1b1cf9b4... python3-elementpath: upgrade 4.3.0 -> 4.4.0
    applied c9711f67270... python3-eth-abi: upgrade 5.0.0 -> 5.0.1
    applied 4d432bbaac5... python3-eth-rlp: upgrade 1.0.1 -> 2.0.0
    applied bf27c3ca167... python3-flask-migrate: upgrade 4.0.5 -> 4.0.7
    applied 79d38afb064... python3-google-api-python-client: upgrade 2.120.0 -> 2.122.0
    applied 974f11b26cb... python3-google-auth: upgrade 2.28.1 -> 2.28.2
    applied 34de4d9d0d1... python3-googleapis-common-protos: upgrade 1.62.0 -> 1.63.0
    applied 9122c0496f3... python3-grpcio-tools: upgrade 1.62.0 -> 1.62.1
    applied 3e156ee399a... python3-grpcio: upgrade 1.62.0 -> 1.62.1
    applied f14a9fe8bed... python3-ipython: upgrade 8.22.1 -> 8.22.2
    applied 9a23ba7d94a... python3-mypy: upgrade 1.8.0 -> 1.9.0
    applied 359d7648632... python3-pydantic: upgrade 2.6.3 -> 2.6.4
    applied b3c96d6708f... python3-pymisp: upgrade 2.4.186 -> 2.4.187
    applied bc2ca24f6df... python3-pymodbus: upgrade 3.6.4 -> 3.6.6
    applied 98242590827... python3-pyperf: upgrade 2.6.2 -> 2.6.3
    applied 75b681b394a... python3-pytest-lazy-fixtures: upgrade 1.0.5 -> 1.0.6
    applied d38f481c801... python3-pytest-timeout: upgrade 2.2.0 -> 2.3.1
    applied 68ae46b2722... python3-requests-oauthlib: upgrade 1.3.1 -> 1.4.0
    applied 24467fcaecc... python3-sentry-sdk: upgrade 1.40.6 -> 1.42.0
    applied 9fd7add621a... python3-tox: upgrade 4.13.0 -> 4.14.1
    applied f27e6981271... python3-traitlets: upgrade 5.14.1 -> 5.14.2
    applied 34a5648d6bd... python3-types-psutil: upgrade 5.9.5.20240205 -> 5.9.5.20240316
    applied 291a582faa9... python3-types-python-dateutil: upgrade 2.8.19.20240106 -> 2.9.0.20240316
    applied 6c1b04a5826... tcsh: upgrade 6.24.10 -> 6.24.11
    applied 9bec1ecc8b5... thingsboard-gateway: upgrade 3.4.4 -> 3.4.5
    applied b3cfb7c9479... xmessage: upgrade 1.0.6 -> 1.0.7
    applied 4007f66b579... xrefresh: upgrade 1.0.7 -> 1.1.0
    applied 20c74cc4e90... Packages depends on libadwaita should require distro feature opengl
    applied 7decf84223c... lvgl: Reinstate demo configuration settings
    applied 0c19e65a096... lvgl: Update to 9.1.0
    applied 7cf7c4c7828... minifi-cpp: upgrade 0.7.0 -> 0.15.0
    applied cb27ff9dcb2... freerdp3: add recipe
    applied 2037afbc328... gperftools: 2.10 -> 2.15
    applied 8f9b4e04b15... openvpn: upgrade 2.6.9 -> 2.6.10
    applied d200b61e244... rocksdb: upgrade 7.9.2 -> 9.0.0
    applied 24f9fdecd85... freerdp3: disable shadow without x11
    applied 831041c60ad... audit: upgrade 4.0 -> 4.0.1
    applied b44c3de71c8... netplan: add missing config directory
    applied 05ed1414851... wireplumber: update 0.4.17 -> 0.5.0
    applied c8c035e99b2... xfstests: upgrade to v2024.03.03
    applied c5328afba4d... lvgl: Drop superfluous ALLOW_EMPTY
    applied c01d979608a... lvgl: Drop unnecessary PV append
    applied 1cb0dae6b8b... lvgl: Deduplicate PACKAGECONFIG into lv-conf
    applied 3c188f75eab... python3-dbus: re-add recipe with latest patches and add ptest
    applied d5602d648dd... tecle: update 45.0 -> 46.0
    applied 62bb96cfb96... gnome-calculator: update 45.0.2 -> 46.0
    applied cf5612a0537... gnome-session: update 45.0 -> 46.0
    applied f47a5184430... gnome-remote-desktop: update 45.1 -> 46.0
    applied 21c81f2bc89... gnome-calendar: update 45.1 -> 46.0
    applied c17d8d9de48... libcamera: Fix clang support patches
    applied fb67e477208... libgweather4: update 4.4.0 -> 4.4.2
    applied 5145c650014... gtksourceview5: update 5.10.0 -> 5.12.0
    applied d205fc49782... gnome-control-center: use gcr4 variant
    applied 45105cb6a9b... libcloudproviders: update 0.3.5 -> 0.3.6
    applied 8db554851f1... gnome-themes-extra: build with gtk+3
    applied c14b40643f7... gtk4mm: add recipe
    applied 48bc28df853... gnome-system-monitor: update 45.0.1 -> 46.0
    applied 14b50435749... gnome-boxes: update 45.0 -> 46.0
    applied b41a6857b88... eog: update 45.2 -> 45.3
    applied cd8e0ece506... gparted: update 1.5.0 -> 1.6.0
    applied df67c7979df... libgtop: update 2.41.1 -> 2.41.3
    applied 02c5765119c... gnome-bluetooth: update 42.8 -> 46.0
    applied c209b3215d1... gnome-text-editor: update 45.1 -> 46.0
    applied 7efc0bc12d1... gnome-chess: update 43.2 -> 46.0
    applied 3dafbcee3fd... gnome-disk-utility: update 45.0 -> 46.0
    applied 6fd8379c51a... gnome-shell-extensions: update 45.2 -> 46.0
    applied 38565a1a893... msgraph: add recipe
    applied 3de9afec60b... gvfs: update 1.52.2 -> 1.54.0
    applied cf49617d4a5... tracker-miners: drop buildpath from tracker-miner-fs-3
    applied 37594d354b9... python3-anyio: Upgrade 4.2.0 -> 4.3.0
    applied a1938bff151... python3-httpx: Upgrade 0.26.0 -> 0.27.0
    applied a06056e7896... plocate: Fix sys/stat.h and linux/stat.h conflicts with musl
    applied 4a40270d16d... liburing: Upgrade to 2.5
    applied e1e5ba58c02... openflow: Delete recipe for 1.0
    applied cb02f5b68d6... openflow: Merge .inc into .bb
    applied 5e7ee914a65... openflow: Fix build with musl
    applied 37ef4d73a24... tracker-miners: Disable seccomp support on musl
    applied 150451eeaf5... evolution-data-server: disable tests and examples
    applied 742c3da8747... libcamera: Fix build on musl systems
    applied ccff89588a5... ipset: Update to 7.21
    applied 860d1a117a6... ot-daemon: Update to tip of trunk
    applied c1d9e520e64... ot-br-posix: Update to latest
    applied 9c00bf17768... wpantund: Update to latest
    applied 777d42c854e... tracker-miners: fix reproducibility issue for landlock
    applied 2526a4b24eb... usrsctp: upgrade to latest version
    applied 371510307df... python3-aiohttp: add missing dependencies
    applied 025e5895756... xfsdump: Fix build with musl >= 1.2.5
    applied fbbe7cefdd0... xfstests: Fix build with musl >= 1.2.5
    applied e9221e89bcb... net-snmp: Fix build with musl
    applied f370d3be8eb... rdma-core: Fix build with musl >= 1.2.5
    applied 7bc6403b733... ssmtp: Fix build with musl >= 1.2.5
    applied f952769a372... autofs: Fix build with musl >= 1.2.5
    applied 85fa15cab87... rsyslog: update from 8.2306.0 to 8.2402.0
    applied 4a238931680... python3-multidict: Upgrade 6.0.4 -> 6.0.5
    applied 0bae6742322... python3-croniter: Upgrade 2.0.1 -> 2.0.3
    applied ff59eced7c2... python3-paho-mqtt: Upgrade 1.6.1 -> 2.0.0
    applied d0736e800df... lvm2: Fix build with musl 1.5.2+
    applied b175cf714b1... sanlock: Fix build with musl >= 1.2.5
    applied 7bfcc56748a... ndctl: Fix build issues seen with musl 1.2.5
    applied 6e0d48562b4... sdbus-c++-libsystemd: Upgrade to 255.4 release of systemd
    applied aa1a4a8cdfe... sdbus-c++,sdbus-c++-tools: Upgrade to 1.5.0 release
    applied baf8e1e39b2... wtmpdb: Upgrade to 0.11.0 release
    applied 6f4ed3a094e... uftrace: Fix build with musl >= 1.2.5
    applied 10fb90ef3c8... fio: Upgrade to 3.36+git
    applied 2de9cb6ec79... i2cdev: Include libgen.h on musl
    applied 77dc06c317d... directfb: Fix build with musl >= 1.2.5
    applied df11d22ecf4... iwd: Upgrade to 2.16
    applied 33d76f24816... file-roller: update 43.1 -> 44.0
    applied 3af965c90eb... strongswan: upgrade 5.9.13 -> 5.9.14
    applied 83c80dd111a... nftables: Add DESCRIPTION and HOMEPAGE
    applied 1ea98b7bfe3... python3-portalocker: enable ptest
    applied c2a5221fa77... soci: fix buildpaths warning
    applied b0ca28a7e01... libcpr: add new recipe
    applied 79fb44fa43a... minifi-cpp: Fix libsodium build on aarch64/clang
    applied 85e9c3548e7... multipath-tools: Fix build with musl >= 1.2.5
    applied 063cde60409... thin-provisioning-tools: install binary to ${sbindir}
    applied d46d2caa25a... python3-typeguard: Upgrade 4.1.5 -> 4.2.1
    applied 360e6fbe173... python3-cachetools: Upgrade 5.3.2 -> 5.3.3
    applied 5f6b96e5beb... python3-django: upgrade 4.2.10 -> 4.2.11
    applied 9660163c4f9... python3-grpcio: cleanup dependencies
    applied 02b230b7f42... aer-inject:add new recipe
    applied 0a815da7bdb... aer-inject: Fix build with latest musl
    applied b1ed6a24f86... aer-inject: Replace hardcoded /usr with ${prefix}
    applied a0a11436175... microsoft-gsl: add new recipe including ptest
    applied 82b160f1d9a... microsoft-gsl: Disable disabled-macro-expansion warning as error on clang/musl
    applied 6665650b2a6... apache2: preset mpm=prefork by default
    applied 0586dd9f134... gnome-user-share: add recipe
    applied 8cf3df2994f... gnome-control-center: update 46.0 -> 46.0.1
    applied aed20cd843f... gtkmm4: add x11 to REQUIRED_DISTRO_FEATURES
    applied 1f28cb0baf2... gdm: update 45.0.1 -> 46.0
    applied df763fc1d07... python3-validators: upgrade 0.22.0 > 0.24.0 and enable ptest
    applied 846418dc8b4... python3-pydbus: Drop ${PYTHON_PN}
    applied 78980a0a1b2... gnome-user-share: remove hardcoded paths
    applied 55017a608e5... python3-ecdsa: remove python3-pbr
    applied a81c30edea9... meta-python-image-ptest: Use 2G RAM for some demanding tests
    applied 90668d6fc60... liberror-perl: move recipe from oe-core
    applied 0d371cf1d15... ghex: update 45.1 -> 46.0
    applied decc39de2af... cppzmq-dev expects /usr/lib/libzmq.a
    applied 2219ceeb48d... gjs: upgrade 1.80.0 -> 1.80.2
    applied 0ddd0768278... gnome-backgrounds: upgrade 45.0 -> 46.0
    applied d49a8e38086... gnome-font-viewer: upgrade 45.0 -> 46.0
    applied c43d9e1c18f... libblockdev: upgrade 3.1.0 -> 3.1.1
    applied 8029c45701c... libdeflate: upgrade 1.19 -> 1.20
    applied 770f0b97c0e... libmbim: upgrade 1.30.0 -> 1.31.2
    applied 3d3eea39abe... libqmi: upgrade 1.34.0 -> 1.35.2
    applied 3d8dec72de6... libtommath: upgrade 1.2.1 -> 1.3.0
    applied afd7afbbae0... mcelog: upgrade 197 -> 198
    applied 796db55dc7c... metacity: upgrade 3.50.0 -> 3.52.0
    applied 995bac1a612... python3-asgiref: upgrade 3.7.2 -> 3.8.1
    applied 02b9fb3f85a... python3-blivet: upgrade 3.9.1 -> 3.9.2
    applied dca7c04a8ad... python3-cassandra-driver: upgrade 3.29.0 -> 3.29.1
    applied dee23aebb8b... python3-djangorestframework: upgrade 3.14.0 -> 3.15.1
    applied 98cb1b38cbf... python3-eth-rlp: upgrade 2.0.0 -> 2.1.0
    applied 4e3e85c685a... python3-eventlet: upgrade 0.35.2 -> 0.36.1
    applied edd4779ed87... python3-filelock: upgrade 3.13.1 -> 3.13.3
    applied 3b614b0b64e... python3-flask-marshmallow: upgrade 1.2.0 -> 1.2.1
    applied c0159f81ee3... python3-flatbuffers: upgrade 24.3.7 -> 24.3.25
    applied 7fd541b3d82... python3-google-api-core: upgrade 2.17.1 -> 2.18.0
    applied 2a9127a51ec... python3-google-api-python-client: upgrade 2.122.0 -> 2.124.0
    applied 583938a0945... python3-google-auth: upgrade 2.28.2 -> 2.29.0
    applied 1beca88b5cf... python3-graphviz: upgrade 0.20.1 -> 0.20.3
    applied a9c445f408e... python3-gspread: upgrade 6.0.2 -> 6.1.0
    applied 545eb9110c1... python3-jdatetime: upgrade 4.1.1 -> 5.0.0
    applied 67d2012d6f8... python3-pdm: upgrade 2.12.4 -> 2.13.2
    applied f474f669fb1... python3-pyasn1-modules: upgrade 0.3.0 -> 0.4.0
    applied 021d260f4d8... python3-pymisp: upgrade 2.4.187 -> 2.4.188
    applied 1490fd58eb1... python3-pytest-asyncio: upgrade 0.23.5 -> 0.23.6
    applied 0ae69566e65... python3-pytest-cov: upgrade 4.1.0 -> 5.0.0
    applied 416bf714510... python3-pytest-lazy-fixtures: upgrade 1.0.6 -> 1.0.7
    applied 8d9ca62e5b0... python3-pywbem: upgrade 1.6.2 -> 1.6.3
    applied 14858176f35... python3-pywbemtools: upgrade 1.2.0 -> 1.2.1
    applied 7de9c8f80ac... python3-pyzstd: upgrade 0.15.9 -> 0.15.10
    applied df5c81a49e3... python3-requests-oauthlib: upgrade 1.4.0 -> 2.0.0
    applied 0c43121ca4e... python3-sentry-sdk: upgrade 1.42.0 -> 1.44.0
    applied 3237d11b620... python3-socketio: upgrade 5.11.1 -> 5.11.2
    applied dbd0cfe921e... python3-thrift: upgrade 0.16.0 -> 0.20.0
    applied f63f2e86271... python3-tox: upgrade 4.14.1 -> 4.14.2
    applied 9d6c9be2019... python3-web3: upgrade 6.15.1 -> 6.16.0
    applied 79a024155b1... st: upgrade 0.9 -> 0.9.1
    applied e0f9a0011c4... thingsboard-gateway: upgrade 3.4.5 -> 3.4.6
    applied 2de743efaaa... thrift: upgrade 0.19.0 -> 0.20.0
    applied 457c531f165... tracker-miners: upgrade 3.7.0 -> 3.7.1
    applied eb5aa5a1cd9... tracker: upgrade 3.7.0 -> 3.7.1
    applied dd5164af893... wireshark: upgrade 4.2.3 -> 4.2.4
    applied 3203483b5f4... wolfssl: upgrade 5.6.6 -> 5.7.0
    applied eae2a3104bf... freeradius: 3.0.26 -> 3.2.3
    applied 28defafdc5f... python3-ecdsa: cleanup DEPENDS
    applied 322ab7587f3... libjxl: add recipe
    applied b40b28fffd0... gnome-backgrounds: add runtime depenency for libjxl
    applied 2a73de83bfe... uutils-coreutils: upgrade 0.0.24 -> 0.0.25
    applied d85547db5a8... highway: add recipe
    applied 5c2de83cc21... python: python-libusb1: add recipe
    applied 77fcf5acd7f... nftables: Fix ptest output format issues
    applied c3541b903fe... nftables: Fix ShellCheck violations in ptest wrapper script "run-ptest"
    applied b5573a4896d... nftables: Fix failed ptest testcases
    applied 0bee442a0ee... lvgl: Set resolution prior to buffer
    applied 896a7f638cb... webkitgtk3: update 2.42.5 -> 2.44.0
    applied 3b82b10eec8... gnome-control-center: restore Upstream-Status line
    applied a8b2cdc20e1... python3-pydbus: Add bash dependency for ptests
    applied a6bcdca5b46... highway,libjxl: Remove -mfp16-format=ieee when using clang compiler

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
