### PR TITLE
subtree update: 7c4a06270c -> 86c303490d

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,29 +2,29 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 17df9c4ebc6614da641dcb9e85246171d940098d
+last_revision = 981425c54e36e3414ab1abadd2c7b1f684f2c1ff
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 4958bfe01324f0bfcc2414fc694e27d3c4111f53
+last_revision = 487a2d569554ef62fa779f2ac39c4fe61b002bf8
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = 1879cb831f4ea3e532cb5ce9fa0f32be917e8fa3
+last_revision = eb8ffc4e63e5e2f729d90d0cd95b8cffed12ece1
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = master
-last_revision = d1522af21da8d799a8f397aef6359b5ed4dc07fe
+last_revision = b4a8bc606f840ee777f470dcd3ca7f69e2de2f69
 
 [poky]
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = a88251b3e7077d0baf3af5f4f52928dce94aa41d
+last_revision = 5d88faa0f35f0205c1475893d8589d1e6533dcc0
 


### PR DESCRIPTION
meta-openembedded 4958bfe013 -> 487a2d5695:
    applied b0da5033d36f... autoconf-2.13-native_2.13: replace oldincludedir
    applied 2f30540742cb... waf-samba: replace oldincludedir
    applied b4980bfc9791... libcoap: fix CVE-2024-0962
    applied cf4bf3f13aee... python3-ecdsa: enable ptest and add missing runtime dependency
    applied b419e1f55961... python3-networkx: Add BBCLASSEXTEND for native and nativesdk
    applied 0a2e45c551bf... python3-decorator: Add BBCLASSEXTEND for native and nativesdk
    applied dadf5db0983d... python3-tornado: extend for native and nativesdk
    applied 2ea3d1468145... python3-pycurl: extend for native and nativesdk
    applied ebeb32dc0371... ostree: Add missing dependencies for ptests
    applied 9d04d8b33579... unixodbc: Upgrade to 2.3.12
    applied 50f88143781a... pv: Fix ptest failures
    applied b201a26bd928... unixodbc: Enable UTF8 init
    applied 1a03565ce367... psqlodbc: Fix ptests
    applied a7c8ce7f6740... python3-websockets: Remove recipe
    applied 3c1ad6fe52c6... python3-twisted: cleanup FILES and recipe in general
    applied 6f31534c9f1f... edid-decode: allow to build native variant
    applied 47ccb88d9485... freediameter: Upgrade to latest on master 1.5.0+
    applied 3ae92547303e... meta-python: missing closing brace
    applied 7b3b303c738b... c-ares: Improve the ptest output
    applied 92e149ec0746... docopt.cpp: turn boost to a PACKAGECONFIG option
    applied fd208c871429... docopt.cpp: add support for native and nativesdk
    applied d3a16ad4aec3... Use PYTHON_SITEPACKAGES_DIR instead of hard-coded site-packages directory path
    applied e191174390a5... python3-pychromecast: upgrade 14.0.0 -> 14.0.1
    applied 28ff6337afc8... python3-zeroconf: upgrade 0.131.0 -> 0.132.0
    applied 84712861e97a... python3-sqlalchemy: upgrade 2.0.27 -> 2.0.29
    applied ad340c8fe23e... Revert "libtorrent: remove CVE mention"
    applied c4107ba77e70... avro: extend avro-c++ to native and nativesdk
    applied 891162dbb44d... libdaq: update to latest stable version 3.0.14
    applied 3716379d3f78... snort3: update to latest stable version 3.1.84.0
    applied 01390732259d... ydotool: Add new package
    applied 24044fd3a010... libjxl: drop -mfp16-format=ieee
    applied c90c045775ed... python3-scrypt: Move from PTESTS_PROBLEMS_META_PYTHON to PTESTS_SLOW_META_PYTHON
    applied 4d41a110529f... Revert "nng: upgrade 1.5.2 -> 12"
    applied 8d6078b19b9f... nng: upgrade 1.5.2 -> 1.7.3
    applied ffb9e53b12bb... libtorrent: remove incorrect CVE mapping
    applied 61bcec12151d... libtorrent-rasterbar: fix CVE mapping
    applied 392b8447223d... libcbor: use shared libraries
    applied d510636b95ef... abseil-cpp: upgrade 20240116.1 -> 20240116.2
    applied baab654008e1... adw-gtk3: upgrade 5.2 -> 5.3
    applied 2f4f2cfef1de... bindfs: upgrade 1.17.6 -> 1.17.7
    applied c7a2dde455c1... cryptsetup: upgrade 2.7.1 -> 2.7.2
    applied f6b1a0f73135... file-roller: upgrade 44.0 -> 44.1
    applied 20d214010aee... gnome-online-accounts: upgrade 3.50.0 -> 3.50.1
    applied 2969bba6dbf6... gnome-text-editor: upgrade 46.0 -> 46.1
    applied 03f95c59ae1d... gtkwave: upgrade 3.3.117 -> 3.3.119
    applied 0c3d4c5a304a... hwdata: upgrade 0.380 -> 0.381
    applied 10c4507b53e9... libbpf: upgrade 1.3.0 -> 1.4.0
    applied 20ea3999df93... libcrypt-openssl-random-perl: upgrade 0.15 -> 0.16
    applied beb832955e5b... libopus: upgrade 1.5.1 -> 1.5.2
    applied d4ce52c1e748... makedumpfile: upgrade 1.7.4 -> 1.7.5
    applied 89af1300cfce... opensc: upgrade 0.25.0 -> 0.25.1
    applied 8563c330549a... python3-aiodns: upgrade 3.1.1 -> 3.2.0
    applied d107f358bce5... python3-aiohttp: upgrade 3.9.3 -> 3.9.4
    applied 08b6f126322a... python3-cbor2: upgrade 5.6.2 -> 5.6.3
    applied 00e390e611b8... python3-django: upgrade 5.0.3 -> 5.0.4
    applied 0069363f261a... python3-eth-abi: upgrade 5.0.1 -> 5.1.0
    applied e4b687c2c4e6... python3-eth-account: upgrade 0.11.0 -> 0.12.1
    applied 39a4c6ed8d3b... python3-eth-typing: upgrade 4.0.0 -> 4.1.0
    applied 1c755d1a2d95... python3-execnet: upgrade 2.0.2 -> 2.1.1
    applied 9c18bb1ada30... python3-filelock: upgrade 3.13.3 -> 3.13.4
    applied f6db1f738f7e... python3-google-api-python-client: upgrade 2.124.0 -> 2.125.0
    applied 1c716a99c23d... python3-ipython: upgrade 8.22.2 -> 8.23.0
    applied 2cc5fb4bb688... python3-javaobj-py3: upgrade 0.4.3 -> 0.4.4
    applied 0dc34e2d41ea... python3-joblib: upgrade 1.3.2 -> 1.4.0
    applied 8607271e6364... python3-parso: upgrade 0.8.3 -> 0.8.4
    applied de060994201a... python3-path: upgrade 16.10.0 -> 16.14.0
    applied 8848b7b8d69a... python3-pdm: upgrade 2.13.2 -> 2.14.0
    applied c5df6e5e40d0... python3-pulsectl: upgrade 23.5.2 -> 24.4.0
    applied e8869a25d05b... python3-pydantic: upgrade 2.6.4 -> 2.7.0
    applied cb74f0eab237... python3-pymodbus: upgrade 3.6.6 -> 3.6.7
    applied 5f8cac646605... python3-rarfile: upgrade 4.1 -> 4.2
    applied 33cd26f80329... python3-send2trash: upgrade 1.8.2 -> 1.8.3
    applied 370ac7784b43... python3-sentry-sdk: upgrade 1.44.0 -> 1.45.0
    applied c1fb68c20fa9... python3-validators: upgrade 0.24.0 -> 0.28.0
    applied 24c2f5febeb0... python3-web3: upgrade 6.16.0 -> 6.17.0
    applied ca39c1572ce7... python3-zopeinterface: upgrade 6.2 -> 6.3
    applied 2824a7ef3981... rdma-core: upgrade 50.0 -> 51.0
    applied b58ee068c148... sngrep: upgrade 1.8.0 -> 1.8.1
    applied 8c1aa2b8aefa... squid: upgrade 6.8 -> 6.9
    applied a89841853836... st: upgrade 0.9.1 -> 0.9.2
    applied 25346e6908a8... tcsh: upgrade 6.24.11 -> 6.24.12
    applied af3d9fe2915b... toybox: upgrade 0.8.10 -> 0.8.11
    applied a0ac2f52909d... webkitgtk3: upgrade 2.44.0 -> 2.44.1
    applied 37f98cb03856... xmlsec1: upgrade 1.3.3 -> 1.3.4
    applied 5f2f51409e0a... yajl: set correct homepage
    applied c341cdb58cf7... apache2: Upgrade v2.4.58 -> v2.4.59
    applied 0ef3e9918dce... freediameter: fix dependency from libidn to libidn2
    applied a85d23b31491... python3-traitlets: Upgrade to 5.14.3
    applied 534032bbe223... pipewire: update 1.0.4 -> 1.0.5
    applied b5ebed99e218... wireplumber: update 0.5.0 -> 0.5.1
    applied d607d161bf6c... aravis: new recipe
    applied eb30a6b92ba4... sdbus-c++: Fix build and upgrade to latest git
    applied 87cdaf04b1e1... ydotool: Do not package systemd unit files on non-systemd distros
    applied e2c174b82a9f... gnome-shell: update 46.0 -> 46.1
    applied f7d2f50cd783... mutter: update 46.0 -> 46.1
    applied 9fc1c3c7a36e... xdg-desktop-portal-gnome: update 46.0 -> 46.1
    applied 2b1183ec4287... gnome-calendar: update 46.0 -> 46.1
    applied 791d42e15049... gnome-shell-extensions: update 46.0 -> 46.1
    applied 1d9962de9e37... vlc: do not depend on mpeg2dec
    applied d28627e55017... gst-instruments: enable ui PACKAGECONFIG only with GTK3DISTROFEATURES
    applied 1df8acab7d26... aravis: fix LICENSE and enable viewer PACKAGECONFIG only with GTK3DISTROFEATURES
    applied 96bf8c25c9da... asio: upgrade 1.28.0 -> 1.30.2
    applied ba36a1b305a3... gensio: upgrade 2.8.3 -> 2.8.4
    applied 2c29715d112a... mpich: upgrade 4.2.0 -> 4.2.1
    applied d7d1da7a9658... openfortivpn: upgrade 1.21.0 -> 1.22.0
    applied 06b0a6244c64... python3-argcomplete: upgrade 3.2.3 -> 3.3.0
    applied 45be5df20517... python3-croniter: upgrade 2.0.3 -> 2.0.5
    applied 6f47be146129... python3-grpcio-tools: upgrade 1.62.1 -> 1.62.2
    applied 696c9d8aa747... python3-grpcio: upgrade 1.62.1 -> 1.62.2
    applied 982d17a783c3... python3-pycups: upgrade 2.0.1 -> 2.0.4
    applied 3fe95086c364... python3-pymisp: upgrade 2.4.188 -> 2.4.190
    applied fc08565d683b... python3-pywbem: upgrade 1.6.3 -> 1.7.2
    applied d48b845c3038... python3-pywbemtools: upgrade 1.2.1 -> 1.3.0
    applied b3bba811d79a... python3-regex: upgrade 2023.12.25 -> 2024.4.16
    applied 031d742ef1f4... python3-yamlloader: upgrade 1.3.2 -> 1.4.1
    applied 76964620a7af... sanlock: upgrade 3.9.1 -> 3.9.2
    applied 3e27517f7e1d... spice-gtk: use hwdata instead of usbids
    applied c203e6afa820... spice-gtk: add PACKAGECONFIG for webdav
    applied 6c10c056a512... gnome-remote-desktop: update 46.0 -> 46.1
    applied 900ef2731f2e... python3-twisted: upgrade 22.10.0 -> 24.3.0
    applied 0dba41b51f1d... python3-incremental: cleanup RDEPENDS and use python_setuptools_build_meta
    applied 94a65e3ff65f... python3-txdbus: cleanup RDEPENDS
    applied 6f4501734f28... Add class for appending dm-verity hash data to block device images
    applied eb61d84e3c21... soci: update build options
    applied ad1f7eb2d372... python3-colorlog: BBCLASEXTEND native nativesdk
    applied 2918c900419a... python3-gcovr: add dep on python3-colorlog
    applied 5d6fa87b3f23... gnome-control-center: update 46.0.1 -> 46.1
    applied ea701b46ba8e... gupnp: fix reproducibility issue
    applied fb31a0706fe3... gssdp: fix a reproducibility issue
    applied 1de297f7b1a2... rygel: update 0.42.4 -> 0.42.5
    applied 1e5ae73fd301... layers: Add styhead to compatible release series
    applied 6a8eb25f570f... chore(sdbus-c++): upgrade to 2.0.0 release
    applied a6fbd9371cdc... nodejs: upgrade 20.11.1 -> 20.12.2
    applied 25e1917a4444... fwupd: Upgrade to 1.9.18 release
    applied 97cfb0361535... python3-pyhamcrest: cleanup RDEPENDS and correct build backend
    applied 704bec8e01c9... python3-protobuf: drop python3-six from RDEPENDS
    applied d3751ce994dc... reproducibility: move repro excludes from AB config.json to meta-oe
    applied 956ebe0cdc15... msgraph: Add opengl to REQUIRED_DISTRO_FEATURES
    applied 4c40897893f4... libgweather: fix build with gobject-introspection 1.80.0
    applied eb9c7bb5645b... st: Update status for CVE-2017-16224
    applied 30e6d975e8d7... procmail: Update status for CVE-1999-0475
    applied 3e3c25698124... mpd: Update status for CVE-2020-7465 and CVE-2020-7466
    applied 996d111343a2... sthttpd: Update status for CVE-2017-10671
    applied 285b9c555bc2... open-vm-tools: Update status for CVE-2014-4199 and CVE-2014-4200
    applied 4fc97fe6027a... networkd-dispatcher: Add dependency on python3-json
    applied 43d20c156a44... networkmanager: fix gir build
    applied a357e89131b1... nautilus: update 45.1 -> 46.1
    applied 01d3dca6e991... renderdoc: remove vim-native DEPENDS
    applied 224eb2697ffd... serial: Fix empty package and use shared lib instead of static lib.
    applied d0fd84b7dff9... nginx: Upgrade stable 1.24.0 -> 1.26.0
    applied a1de57ff67b2... gnome-control-center: move printing RDEPENDS to cups PACKAGECONFIG
    applied a87f7624e1dd... networkmanager: add missing glib-2.0 dependency
    applied 3fd6f0feec00... python3-twisted: remove obsolete python3-twisted-flow
    applied a733b0c75c81... fping: upgrade 5.1 -> 5.2
    applied edccd846b943... iniparser: upgrade 4.1 -> 4.2
    applied 2d118de9f0ea... libgedit-gtksourceview: upgrade 299.1.0 -> 299.2.1
    applied c19cce7a33f4... libmodule-build-tiny-perl: upgrade 0.047 -> 0.048
    applied 19031c56fe46... libmxml: upgrade 3.3.1 -> 4.0.3
    applied e1038f209135... python3-aiohttp: upgrade 3.9.4 -> 3.9.5
    applied b2ef3ebf002c... python3-bitstring: upgrade 4.1.4 -> 4.2.1
    applied b719a893066b... python3-freezegun: upgrade 1.4.0 -> 1.5.0
    applied d35e82680fa6... python3-google-api-python-client: upgrade 2.125.0 -> 2.127.0
    applied 6b12186f1fd7... python3-imageio: upgrade 2.34.0 -> 2.34.1
    applied 2930861f11b3... python3-ipython: upgrade 8.23.0 -> 8.24.0
    applied 592b8a186679... python3-mypy: upgrade 1.9.0 -> 1.10.0
    applied df9b9db334ca... python3-pdm: upgrade 2.14.0 -> 2.15.1
    applied fbd37bafc1bf... python3-platformdirs: upgrade 4.2.0 -> 4.2.1
    applied 6112eb064cca... python3-pydantic: upgrade 2.7.0 -> 2.7.1
    applied ba9c2a8d0654... python3-pymodbus: upgrade 3.6.7 -> 3.6.8
    applied f8fde0a137d7... python3-regex: upgrade 2023.04.16 -> 2024.4.28
    applied b99a11afad0d... python3-rlp: upgrade 4.0.0 -> 4.0.1
    applied fd32cdcdbca1... python3-tox: upgrade 4.14.2 -> 4.15.0
    applied c83665c23ab8... python3-types-psutil: upgrade 5.9.5.20240316 -> 5.9.5.20240423
    applied 098b1320ed85... python3-validators: upgrade 0.28.0 -> 0.28.1
    applied 03ad8060077b... python3-virtualenv: upgrade 20.25.0 -> 20.26.0
    applied 3a6572c1549d... python3-web3: upgrade 6.17.0 -> 6.17.2
    applied a1a5fff37d94... python3-xmlschema: upgrade 3.0.1 -> 3.3.1
    applied 9928afb0e22b... qcbor: upgrade 1.2 -> 1.3
    applied 7d68ac799c6f... ser2net: upgrade 4.6.1 -> 4.6.2
    applied a40b1fa392d2... spdlog: upgrade 1.13.0 -> 1.14.0
    applied 59c62576b40d... tracker-miners: upgrade 3.7.1 -> 3.7.2
    applied 3142a9ca94fc... tracker: upgrade 3.7.1 -> 3.7.2
    applied 86a78344c856... uftrace: upgrade 0.15.2 -> 0.16
    applied 492b1b1adc1c... evince: Update status for CVE-2011-0433 and CVE-2011-5244
    applied 577a55f7a522... mbedtls: Fix warning for missing program
    applied 88f2955e3831... uutils-coreutils: upgrade 0.0.25 -> 0.0.26
    applied 80719a61a53d... fwupd: fix uefi capsule update build error
    applied 69a68d4ded83... nodejs-oe-cache: fix offline install of dependencies
    applied d4e3bdd519ce... spdlog=v1.14.1
    applied 32984eb9fdde... libdeflate: fix build with -mcpu=cortex-a76+crypto without -march=armv8.2-a+crypto
    applied bd1b5cde348d... python3-twisted: prepend split PACKAGES
    applied 5778e32eae20... python3-grpcio: Fix build with gcc-14
    applied 4c815591b033... python3-zeroconf 0.132.0 -> 0.132.2
    applied 0cc5ebd5b430... librelp: Fix build with gcc-14
    applied c302dc142724... pcapplusplus: Fix build with gcc14
    applied 12519f09cd7f... syslog-ng: ignore incompatible-pointer-types issues with gcc-14
    applied 37d1908eeaa8... libtevent: upgrade 0.16.0 -> 0.16.1
    applied 722213211568... samba: upgrade 4.19.5 -> 4.19.6
    applied 57e8d81d6040... oprofile: Fix file_manip_tests ptest
    applied a1e16928bbdc... nodejs: Upgrade to 20.13.0 release
    applied a69bde04bef6... re2: remove dev dependencies from main package
    applied 34ee1ff3547c... php: Upgrade to 8.2.18
    applied d435a32020be... uw-imap: Add a patch to support newer than TLSv1.0
    applied 8b54f1b64d27... composefs: remove fuse3 dependencie
    applied dfae2972b490... composefs: move from meta-filesystems to meta-oe layer
    applied 4acfcfb234d3... composefs: refactor
    applied 7efc8922b7eb... composefs: bump ecef20c1
    applied 850a893f2098... composefs: add native target support
    applied c808ff41af22... vbxguestdrivers: upgrade 7.0.14 -> 7.0.18
    applied 4b14dacf5551... freerdp: Upgrade to 2.11.7
    applied 990e399272d6... freerdp3: Upgrade to 3.5.1 release
    applied fe0996a0433b... xlsfonts: upgrade 1.0.7 -> 1.0.8
    applied 5fe3c7a2d358... xkbutils: upgrade 1.0.5 -> 1.0.6
    applied 88cc44c35983... transmission: Upgrade to 4.0.5
    applied 587edc5e8dc2... fvwm: Fix build with gcc-14
    applied e47585ffc87b... python3-wxgtk4: Fix build with gcc-14
    applied 064f6fae4f7a... gtk+: Disable incompatible-pointer-types warning as error
    applied de813392cf46... fluentbit: Upgrade to 1.9.9
    applied 11ad4a7fb10d... gnome-shell: correct regression with glib-2.0 2.78.5
    applied 97eaa95cf36a... gdm: add missing json-glib dependency
    applied 5b391d507024... gnome-software: update 46.0 -> 46.1
    applied 15ce6f812bd2... gnome-calculator: update 46.0 -> 46.1
    applied 6c5cb3b4eb6a... evince: update 46.0 -> 46.1
    applied db8047fbd1cc... gnome-boxes: update 46.0 -> 46.1
    applied f25bfcbf948c... file-roller: update 44.1 -> 44.2
    applied 9e916094440d... libteam: Upgrade to 1.32 release
    applied 61d407ad599c... rsyslog: Upgrade to 8.2404.0
    applied 03bcc8ffb203... mcelog: Fix build with GCC14 and musl
    applied f804417cda24... geoip-perl: Add ptest missing dependency on perl-modules
    applied 36a1e36e1272... source-han-sans-*-fonts: Switch away from SVN fetcher in SRC_URI
    applied 10d2bd01b346... flatpak: update 1.15.6 -> 1.15.8
    applied 9e57692e9f9f... xdg-desktop-portal: update 1.18.1 -> 1.18.4
    applied c16704f6a38d... python3-looseversion: Move to meta-oe
    applied 7cceba0e2cbe... fuse3: move from meta-filesystems to meta-oe
    applied bf80941c3f12... flatpak;xdg-desktop-portal: add missing runtime dependency on fuse3-utils
    applied c4a330ab89c8... libgpiod: update to v2.1.2
    applied fbb5911127af... orrery: Drop recipe
    applied f6998200a502... dool: upgrade 1.3.1 -> 1.3.2
    applied 05627552612e... gnome-text-editor: upgrade 46.1 -> 46.3
    applied 1615d0e1d638... hwdata: upgrade 0.381 -> 0.382
    applied 368ed98e7e40... libbpf: upgrade 1.4.0 -> 1.4.2
    applied 3d7c2c1c0906... libnet-dns-perl: upgrade 1.40 -> 1.45
    applied f3b2cfa3e45c... libnvme: upgrade 1.8 -> 1.9
    applied 8679b7b930d0... liburing: upgrade 2.5 -> 2.6
    applied 03656602abea... nano: upgrade 7.2 -> 8.0
    applied 9833bfcd752f... ndctl: upgrade v78 -> v79
    applied 41c3ad1a6386... networkmanager-openvpn: upgrade 1.10.2 -> 1.11.0
    applied 4519790c0f5e... opencl-headers: upgrade 2023.12.14 -> 2024.05.08
    applied d058868617fd... opencl-icd-loader: upgrade 2023.12.14 -> 2024.05.08
    applied aa0eb49df03f... openipmi: upgrade 2.0.34 -> 2.0.35
    applied daa251de7a06... postgresql: upgrade 16.2 -> 16.3
    applied 5d96fd323f36... python3-astroid: upgrade 3.1.0 -> 3.2.0
    applied f41ff6bdd58b... python3-asyncinotify: upgrade 4.0.6 -> 4.0.9
    applied d85d15d46767... python3-bitstring: upgrade 4.2.1 -> 4.2.2
    applied 716174e6a1ec... python3-dbus-fast: upgrade 2.21.1 -> 2.21.2
    applied 550418d3b42a... python3-django: upgrade 5.0.4 -> 5.0.6
    applied f87e4ddb7802... python3-filelock: upgrade 3.13.4 -> 3.14.0
    applied 5ba4fd85f6d7... python3-freezegun: upgrade 1.5.0 -> 1.5.1
    applied a88add15f341... python3-gmqtt: upgrade 0.6.14 -> 0.6.16
    applied 36f7916c3b48... python3-google-api-core: upgrade 2.18.0 -> 2.19.0
    applied 54bbf3159642... python3-google-api-python-client: upgrade 2.127.0 -> 2.129.0
    applied fb796f7120c9... python3-imgtool: upgrade 2.0.0 -> 2.1.0
    applied bb89f8b7e921... python3-joblib: upgrade 1.4.0 -> 1.4.2
    applied 8cc2274dbf31... python3-langtable: upgrade 0.0.65 -> 0.0.66
    applied 586146741cf8... python3-marshmallow: upgrade 3.21.1 -> 3.21.2
    applied a70a25240234... python3-moteus: upgrade 0.3.67 -> 0.3.68
    applied 63a9049ec4fe... python3-nocasedict: upgrade 2.0.1 -> 2.0.3
    applied 2ae1b5221100... python3-nocaselist: upgrade 2.0.0 -> 2.0.2
    applied edf60556a223... python3-pdm: upgrade 2.15.1 -> 2.15.2
    applied 8065b67ce443... python3-pyudev: upgrade 0.24.1 -> 0.24.3
    applied c4f74553995f... python3-regex: upgrade 2024.4.28 -> 2024.5.10
    applied c85d1a6b1d0b... python3-sqlalchemy: upgrade 2.0.29 -> 2.0.30
    applied 2ae78254754a... python3-tqdm: upgrade 4.66.2 -> 4.66.4
    applied fe45b1ab956d... python3-types-psutil: upgrade 5.9.5.20240423 -> 5.9.5.20240511
    applied 158fb7b5e349... python3-uswid: upgrade 0.4.7 -> 0.5.0
    applied 37429649e1e2... python3-virtualenv: upgrade 20.26.0 -> 20.26.1
    applied 97fa607158ee... python3-web3: upgrade 6.17.2 -> 6.18.0
    applied 9ef0e887918d... smcroute: upgrade 2.5.6 -> 2.5.7
    applied 9cc20a0203eb... tracker-miners: upgrade 3.7.2 -> 3.7.3
    applied c6a9b1559cc5... tracker: upgrade 3.7.2 -> 3.7.3
    applied dccd6a334149... uriparser: upgrade 0.9.7 -> 0.9.8
    applied 1922fb35f63f... glib-testing: add recipe
    applied da03f5dadc0b... freerdp: fix build with gcc-14
    applied 1573555fb837... python3-grpcio: fix do_compile failure for qemuppc64/qemuppc
    applied 967216f6d7b0... unbound: upgrade 1.19.3 -> 1.20.0
    applied eeef1fddd905... libwebsockets: fix buildpath warnings
    applied 972f3a4b89a5... opentelemetry-cpp: Add recipe
    applied 6ce8cef7e744... poke: Upgrade to 4.0
    applied 13ddd97e4f3b... tinyalsa: Upgrade to tip of trunk
    applied aeb11d81dc57... xterm: Upgrade to 391
    applied 05722a9a0783... malcontent: add recipe
    applied 5d2e783591a3... ostree: Upgrade 2024.5 -> 2024.6
    applied 1429a784c7da... squid: workaround a build failure with native gcc10
    applied ebae86d9ddb5... libndp: Fix build with gcc-14/musl
    applied bc0a51650200... openflow: Fix build build with musl/gcc14
    applied 9cd8c543927b... nvme-cli: upgrade 2.8 -> 2.9.1
    applied 11ca5bc26159... nvme-cli: Fix build on musl
    applied 8579d62df986... malcontent-ui: fix lib install
    applied 3584b79a4cdc... malcontent: move PV to malcontent.inc
    applied d161de0b00b9... mdio-tools: fix mdio-netlink kernel module reproducibility
    applied 852abb05998f... pipewire: update 1.0.5 -> 1.0.6
    applied 79f062bddcab... wireplumber: update 0.5.1 -> 0.5.2
    applied 4ce72171a079... flatpak: add PACKAGECONFIG knob for malcontent
    applied 47bda4da5731... libsdl: Fix build with musl
    applied 7f2fc43e0921... folks: Upgrade to 0.15.9
    applied cfa404026099... xfce4-notes-plugin: Upgrade to 1.11.0
    applied a9d32c3c640e... etcd: Adjust for UNPACKDIR/WORKDIR rework
    applied bc654c300fda... crucible: Adjust for UNPACKDIR/WORKDIR rework
    applied 9d17f797f39f... gosu: Adjust for UNPACKDIR/WORKDIR rework
    applied cd6e2d8f53b4... influxdb: Do not remove non-existing files
    applied bfb2dab80201... xfmpc: Disable incompatible-pointer-types warning as error
    applied 8866910fddb5... sox: Fix build with GCC-14
    applied 5762e4fd5590... nbd: Upgrade to 3.26.1
    applied 5413301d49e6... vlc: Backport fixes to enable GCC-14 based builds
    applied a7c72b59b4d1... gnome-font-viewer: Fix build with GCC-14
    applied c3d347f7eef5... gtksourceview3: Use -Wno-error=incompatible-pointer-types in cflags
    applied d6dd4b89b610... menulibre: Upgrade to 2.4.0
    applied 7b02f14be9cd... gimp: Upgrade to 2.10.38
    applied 673ba54e98c8... nbd: Fix build with GCC14 on musl targets
    applied 46db58f8c731... nbd: Do not inherit systemd
    applied 0b8dc5346b35... pipewire-0.2: Include time.h for timespec struct signature
    applied 35cf63e5f395... directfb: Fix build with musl+GCC14
    applied ddc8a6557fd0... etcd-cpp-apiv3: Fix build on musl + GCC14
    applied 7fe3fbd42dab... etcd-cpp-apiv3: Upgrade to 0.15.4 release
    applied ca6bb4de1fbc... syzkaller: Fix build with musl + gcc14
    applied 805aaefe7778... gsoap: Upgrade to 2.8.134
    applied fe19113d0b2b... gnome-boxes: fix build with gcc14
    applied cbee7cc3dfec... gnome-control-center: add PACKAGECONFIG knob for malcontent
    applied 7f698a94631e... python3-werkzeug: added python3-difflib as RDEPENDS
    applied 9b97a6fe054b... nodejs-oe-cache-native: use UNPACKDIR
    applied 53f608235a20... jemalloc: add +git to version
    applied a90f89dbc7ef... duktape: Use S instead of ${WORKDIR}/duktape-2.7.0
    applied ffc64e9c6fee... recipes: Start WORKDIR -> UNPACKDIR transition
    applied c33cfad1b0e1... recipes: Switch away from S = WORKDIR
    applied 907b9c0ae697... python3-pyruvate: Adjust for WORKDIR -> UNPACKDIR changes
    applied e77507a898cc... apache2: fix multilib file conflicts
    applied cc2ce07b4290... nana: Fix buildpaths warning.
    applied d93d67dab306... fetchmail: Fix buildpaths warning.
    applied cda9ade9fb96... packagegroup-meta-oe: fix lvgl inclusion
    applied 965b0192c508... iniparser: upgrade 4.2 -> 4.2.1
    applied 63fcd2c63912... iniparser: remove dependency on doxygen-native
    applied cfb4c5413162... oscam: Upgrade to 1.20
    applied 14f9af8522b0... uim: Upgrade to 1.8.9
    applied f397be4a72e4... fuse3: remove sysv init script and install fuse kernel module explictly
    applied 08e414d49620... source-han-sans-*-fonts: rename downloaded files in SRC_URI
    applied 58264260c3a0... source-han-sans-*-fonts: move common part to .inc file
    applied 81647e10c2eb... python3-pytest-freezer: new recipe
    applied cdcea59695f4... python3-pytest-socket: new recipe
    applied 1c360127e5b8... python3-pytest-unordered: new recipe
    applied c6cf5fe79ba0... python3-requests-mock: new recipe
    applied 17a1bb00de5b... libwebsockets: remove STAGING_LIBDIR with /
    applied 44b4586c738d... liburing: Use libc on rv64/clang18
    applied f09c477f9a04... hddtemp: Fix reproducibility in fr locale
    applied 88f604fa710f... android-tools: fix building with GCC 14
    applied 6dd9cd977f88... android-tools: fix UNPACKDIR conversion leftovers
    applied 31cdabb9b105... android-tools-configfs: Fix build-time warning about S being non-existent
    applied 07772ae47020... layers: stop declaring compatibility with scarthgap
    applied 1a3d194eb355... libfido2: remove non-functional native and nativesdk BBCLASSEXTEND
    applied 2a18bc7d98bd... libsdl2-image: upgrade to 2.8.2
    applied 6193a1a12f8c... unicode-ucd: fix UNPACKDIR conversion leftovers
    applied 64b8b621b43e... arno-iptables-firewall: upgrade 2.1.1 -> 2.1.2
    applied 535822eff764... cjson: upgrade 1.7.17 -> 1.7.18
    applied 47e3fb8723c6... evince: upgrade 46.1 -> 46.3
    applied 16bd4ae56d7f... file-roller: upgrade 44.2 -> 44.3
    applied 14e8de94d804... gnome-online-accounts: upgrade 3.50.1 -> 3.50.2
    applied 808f2bf90b29... googlebenchmark: upgrade 1.8.3 -> 1.8.4
    applied b6746096f41c... gsl: upgrade 2.7.1 -> 2.8
    applied 4563e25ef858... libass: upgrade 0.17.1 -> 0.17.2
    applied 3202c318b74e... libdevmapper: upgrade 2.03.22 -> 2.03.24
    applied 8c21f4659cf4... msgraph: upgrade 0.2.1 -> 0.2.2
    applied 0268abb2851e... nautilus: upgrade 46.1 -> 46.2
    applied 0f4ab4e8ab1e... python3-annotated-types: upgrade 0.6.0 -> 0.7.0
    applied 2759a8056630... python3-astroid: upgrade 3.2.0 -> 3.2.2
    applied 9f29d38f0094... python3-bitstring: upgrade 4.2.2 -> 4.2.3
    applied 246de2584ddc... python3-dbus-fast: upgrade 2.21.2 -> 2.21.3
    applied ee4085c06a91... python3-google-api-python-client: upgrade 2.129.0 -> 2.130.0
    applied efc4c9875f3e... python3-gspread: upgrade 6.1.0 -> 6.1.2
    applied 5f7d6c374bc6... python3-moteus: upgrade 0.3.68 -> 0.3.70
    applied 123d6086796f... python3-pdm: upgrade 2.15.2 -> 2.15.3
    applied d4090c44e664... python3-platformdirs: upgrade 4.2.1 -> 4.2.2
    applied b51670d13fdf... python3-pycurl: upgrade 7.45.2 -> 7.45.3
    applied 7d6361019565... python3-pylint: upgrade 3.1.0 -> 3.2.2
    applied afb0b53193ef... python3-pyperf: upgrade 2.6.3 -> 2.7.0
    applied ede5de0bf693... python3-pyzstd: upgrade 0.15.10 -> 0.16.0
    applied 32c750f384eb... python3-rapidjson: upgrade 1.14 -> 1.17
    applied 4cf3e06bf131... python3-regex: upgrade 2024.5.10 -> 2024.5.15
    applied ad8b9b2baa52... python3-transitions: upgrade 0.9.0 -> 0.9.1
    applied 4b064f2a7350... python3-twine: upgrade 5.0.0 -> 5.1.0
    applied c68ba3ea86c8... python3-types-psutil: upgrade 5.9.5.20240511 -> 5.9.5.20240516
    applied 868ba2a93263... python3-types-setuptools: upgrade 69.0.0.20240125 -> 70.0.0.20240524
    applied 66cb9007b0bb... python3-ujson: upgrade 5.9.0 -> 5.10.0
    applied 307ed5253448... python3-validators: upgrade 0.28.1 -> 0.28.3
    applied be79139bb5f4... python3-virtualenv: upgrade 20.26.1 -> 20.26.2
    applied fa5b821b1142... python3-watchdog: upgrade 4.0.0 -> 4.0.1
    applied 77254517f31c... python3-web3: upgrade 6.18.0 -> 6.19.0
    applied 8c8dc2febb89... redis: upgrade 7.2.4 -> 7.2.5
    applied 99a1d03a2ec4... thingsboard-gateway: upgrade 3.4.6 -> 3.5
    applied dd8517b8048b... webkitgtk3: upgrade 2.44.1 -> 2.44.2
    applied 7f56ae763faa... wireshark: upgrade 4.2.4 -> 4.2.5
    applied 1e5179077af8... xterm: upgrade 391 -> 392
    applied cc4e9fbd823a... lvm2: remove subitted patch
    applied 378a095d2de3... mutter: update 46.1 -> 46.2
    applied ab98a21460e8... gnome-control-center: update 46.1 -> 46.2
    applied b1c98c3d9146... gnome-shell: update 46.1 -> 46.2
    applied a17cc2d6bf65... gnome-software: update 46.1 -> 46.2
    applied 27571a6ec2aa... xdg-desktop-portal-gnome: update 46.1 -> 46.2
    applied 7ecfdeb3cf4e... gnome-remote-desktop: update 46.1 -> 46.2
    applied 86b7862ae45a... android-tools: fix adb/libssl-1.1 patch
    applied 0b96a041fad5... iniparser: use SHA hash for srcrev
    applied ab916d731178... sample-content: Set UNPACKDIR to S to avoid a QA warning
    applied 9813fb56d22a... ckermit: Define return type for main
    applied 2452baba077d... googlebenchmark: Fix type conversion errors found with clang
    applied ad2407d92a11... protobuf: Fix build on riscv32
    applied 31cdde863477... mariadb: Fix build on riscv32
    applied a47a40a3e4d1... minifi-cpp: Fix build with clang and riscv32
    applied edaefe7f80be... dav1d: update 1.4.1 -> 1.4.2
    applied 5cf3766cf639... nftables: avoid python dependencies when building without python
    applied ad437d52372e... hostapd: Support running "devtool modify hostapd"
    applied 2648f532bfc7... hostapd: Only include the relevant parts from README in LIC_FILES_CHKSUM
    applied e1bced739968... libjs-jquery-icheck: Correct LIC_FILES_CHKSUM
    applied 1d5c3e17f536... python3-dasbus: Add new recipe
    applied c67c3f4232b2... python3-flask: add ptest
    applied 446afe97d8ba... lvm2: restore Upstream-Status
    applied 5b497bb839b5... exfatprogs: upgrade 1.2.2 -> 1.2.3
    applied d859a692ad0b... sdbus-c++-libsystemd: Upgrade to 255.6
    applied 1a5807e4c77b... python3-flask: upgrade 3.0.2 -> 3.0.3
    applied dc942a392f55... libgphoto2: fix build with gcc-14
    applied 446560ab41de... python3-icu: upgrade from 2.12 to 2.13.1 to fix build with icu-75
    applied 0e456ad6b3ea... python3-dasbus: Add ptest support
    applied ca28badd147a... python3-pytest-html: add missing runtime dependencies
    applied e81ffda3b481... ostree: Append to UNKNOWN_CONFIGURE_OPT_IGNORE instead of override
    applied 5a4e4c532cbe... android-tools-configfs: Fix build-time warning about S in a second instance of recipe
    applied 91054de77789... libcamera: update to 0.3.0
    applied 868ca4d3a7d3... dhrystone: fix building with the GCC 14
    applied 665d4684c8f9... xscreensaver: remove obsolete append_libtool_sysroot
    applied 22dc90b02b26... sdbus-c++-libsystemd: Refresh patches to work with systemd 255.6
    applied 3aa9469b2c2d... python3-pydantic-core: Remove crutch to get module working on musl
    applied 2d11258e2d31... frr: update 9.1 to 10.0
    applied 2f38b4028d8c... rrdtool: fix compilation with GCC 14
    applied 6a8650ac4b22... lmsensors: fix building with GCC 14
    applied 95fbda562580... ntopng: fix building with GCC 14
    applied 05c17b63fe0b... rrdtool: Fix do_populate_sysroot QA issues
    applied bfc372f8c49e... cukinia: upgrade 0.6.2 -> 0.7.0
    applied db6540fee146... mdns: Upgrade 2200.100.94.0.2 -> 2200.120.24
    applied a45050c64338... python3-pydantic: Upgrade to 2.7.2
    applied a8976d9d3b20... sexpect: add new recipe
    applied d5db852e4e45... atkmm-2.36: upgrade 2.36.2 -> 2.36.3
    applied b2aea7bec101... botan: upgrade 3.2.0 -> 3.4.0
    applied cbd98eb9aa83... bubblewrap: upgrade 0.8.0 -> 0.9.0
    applied 3349add908e2... cglm: upgrade 0.9.2 -> 0.9.4
    applied f016f7779650... colord-native: upgrade 1.4.6 -> 1.4.7
    applied b6e5565ebdbc... composefs: upgrade 1.0.3 -> 1.0.4
    applied c2469b4fb551... ctags: upgrade 6.1.20240310.0 -> 6.1.20240602.0
    applied eb6d56d77771... editorconfig-core-c: upgrade 0.12.6 -> 0.12.7
    applied c895c82a15c2... exiftool: upgrade 12.72 -> 12.85
    applied 11ff9bb108cb... glibmm-2.68: upgrade 2.78.0 -> 2.80.0
    applied 713785761d3b... highway: upgrade 1.1.0 -> 1.2.0
    applied 3db6d7d5a2b8... hwdata: upgrade 0.382 -> 0.383
    applied ac1756f1b79d... iperf3: upgrade 3.16 -> 3.17.1
    applied 9993925b6751... iscsi-initiator-utils: upgrade 2.1.8 -> 2.1.10
    applied c20568adfb25... libcgi-perl: upgrade 4.60 -> 4.64
    applied d2dacef7021d... libcompress-raw-bzip2-perl: upgrade 2.206 -> 2.212
    applied 0a2d566589f7... libcompress-raw-lzma-perl: upgrade 2.206 -> 2.212
    applied 5c36491f037e... libcompress-raw-zlib-perl: upgrade 2.206 -> 2.212
    applied 1b0f933f5b07... libiec61850: upgrade 1.5.1 -> 1.5.3
    applied 012926d1ce44... libio-compress-lzma-perl: upgrade 2.206 -> 2.212
    applied 3dbb98a90872... libio-compress-perl: upgrade 2.206 -> 2.212
    applied 2d78fc201079... libsodium: upgrade 1.0.19 -> 1.0.20
    applied fe5bd08e57a9... libtracefs: upgrade 1.7.0 -> 1.8.0
    applied 911023b521be... libvpx: upgrade 1.14.0 -> 1.14.1
    applied 7596d6a497e3... mcelog: upgrade 198 -> 199
    applied 6e7c4345b5bd... mercurial: upgrade 6.5 -> 6.6.3
    applied 531a08bf1419... monit: upgrade 5.33.0 -> 5.34.0
    applied 485dfc19be34... networkmanager: upgrade 1.46.0 -> 1.48.0
    applied a5f414bc460f... ntp: upgrade 4.2.8p17 -> 4.2.8p18
    applied 7cd1f5a87175... openfortivpn: upgrade 1.22.0 -> 1.22.1
    applied 446cce1c8262... pangomm-2.48: upgrade 2.50.1 -> 2.52.0
    applied 9bd2f7567776... pmdk: upgrade 2.0.0 -> 2.1.0
    applied 2ccaf19c5ba8... poco: upgrade 1.12.5p2 -> 1.13.3
    applied cf61a35fd7dc... poke: upgrade 4.0 -> 4.1
    applied d06a9c504928... meta-oe/conf/layer.conf: remove libbpf from NON_MULTILIB_RECIPES for x86 and x86-64
    applied 6b9167400b0e... python3-gevent: fix build with Cython 3.0.10
    applied 7d5e32b7e9a9... python3-h5py: upgrade to 3.11.0
    applied da13475f00b0... usleep: fix compile errors
    applied ae843182b4d6... dracut: Switch to dracut-ng and upgrade to version 102
    applied 8d4c43097357... unixodbc: Fix CVE-2024-1013
    applied 80d1d51ff3b9... cdrkit: fix incompatible pointer type error
    applied 3e28f9152c0c... libimobiledevice-glue: upgrade 1.0.0 -> 1.2.0
    applied 2bdba8ba4578... libirecovery: upgrade 1.1.0 -> 1.2.0
    applied 2b33e916ff8f... googlebenchmark: Update patch and its status to backport
    applied 751cb7534cd1... networkmanager: Fix undefined symbol errors on musl+lld
    applied f25f77bdf632... uw-imap: fix incompatible pointer type errors
    applied d0d0e6efb991... daq: fix incompatible pointer type error
    applied 4a085af2e61b... libdbd-mysql-perl,rrdtool: Disable gcc option -Wincompatible-pointer-types
    applied 5e2f13aec611... mozjs-115: update 115.8.0 -> 115.11.0
    applied 42b87cb03280... libdbd-mysql-perl: update 4.050 -> 5.006
    applied 395e9075acef... python3-pefile: Move from meta-python to meta-oe
    applied 10fc3fa15f00... fwupd-efi: Upgrade to 1.6
    applied d40a28da04b3... libgee: downgrade incompatible-pointer-types back to warning
    applied 0ec2b7aab2c5... replace libdbd-mysql-perl with dbd-mariadb
    applied b235b47cb6b0... dracut: Drop an unnecessary patch
    applied f22451b51bf6... fbida: Require opengl feature for pdf only
    applied 8b013028356b... udpcast: add recipe
    applied 185e779bad07... googlebenchmark: Fix build on riscv64
    applied feb01d3ed8f9... cmpi-bindings: Fix build error with gcc14.
    applied 41c2cf74c5a3... c-ares: Update SRC tarball path
    applied 6bccd43e8fdf... libjxl: Turn sizeless vectors as a packageconfig option
    applied 4b4086edef22... libgpiod: update to v1.6.5
    applied 1e477be454f4... libgpiod: disable C++ tests for libgpiod v1.6.x
    applied 06eb303345bc... iwd: update 2.16 -> 2.18
    applied 02f2a297ea64... catch2: Upgrade to 3.x release series
    applied 2c8d82ea2f4a... libgpiod: Migrate to catch2 v3
    applied 0c93219cf1eb... wireplumber: update 0.5.2 -> 0.5.3
    applied 45f1bd0933a0... pipewire: update 1.0.6 -> 1.0.7
    applied 912744869310... usbguard: upgrade 1.1.2 -> 1.1.3
    applied 8b0be4be2b7a... abseil-cpp: backport RISC-V fix
    applied 080287ebe1f6... python3-grpcio: backport abseil-cpp RISC-V fix
    applied 17e30b3bb299... dfu-util: allow building nativesdk variant
    applied 56e2e5df9bba... python3-pyyaml-include: support native and nativesdk build
    applied 6fa4449acea3... python3-anyio: upgrade 4.3.0 -> 4.4.0
    applied 90c606e2495b... python3-autoflake: upgrade 2.2.1 -> 2.3.1
    applied 88105e6ce8d9... python3-bidict: upgrade 0.23.0 -> 0.23.1
    applied 343c22a48d0e... python3-cantools: upgrade 39.4.4 -> 39.4.5
    applied 7f7dcf8011fa... python3-coverage: upgrade 7.4.1 -> 7.5.3
    applied 0dd1264a9499... python3-email-validator: upgrade 2.1.0 -> 2.1.1
    applied 85eabb8a9dad... python3-eth-hash: upgrade 0.6.0 -> 0.7.0
    applied 5a51c745a651... python3-evdev: upgrade 1.6.1 -> 1.7.1
    applied 9c7a72cbc234... python3-future: upgrade 0.18.3 -> 1.0.0
    applied 2735912307c5... python3-google-api-python-client: upgrade 2.130.0 -> 2.131.0
    applied 3194be1e1536... python3-hexbytes: upgrade 1.0.0 -> 1.2.0
    applied 6801e96a81ef... python3-html2text: upgrade 2020.1.16 -> 2024.2.26
    applied e21ef8fcc33b... python3-httpcore: upgrade 1.0.3 -> 1.0.5
    applied e0593a5b65e7... python3-ipython: upgrade 8.24.0 -> 8.25.0
    applied ea97646a59fb... python3-msgpack: upgrade 1.0.7 -> 1.0.8
    applied 7106f0c04175... python3-netaddr: upgrade 1.2.1 -> 1.3.0
    applied 197bc2add5e3... python3-openpyxl: upgrade 3.1.2 -> 3.1.3
    applied e724052584e4... python3-pdm-backend: upgrade 2.1.8 -> 2.3.0
    applied f782665cfb16... python3-pdm: upgrade 2.15.3 -> 2.15.4
    applied 2f6cc1032e7b... python3-prompt-toolkit: upgrade 3.0.43 -> 3.0.45
    applied 45fe80c61668... python3-py7zr: upgrade 0.20.8 -> 0.21.0
    applied 7b5ec9d5fae4... python3-pyalsaaudio: upgrade 0.10.0 -> 0.11.0
    applied 2a4dac7e4d19... python3-pybind11-json: upgrade 0.2.13 -> 0.2.14
    applied 372f830c6860... python3-pymongo: upgrade 4.6.1 -> 4.7.2
    applied 189bee4bdbd5... python3-pyroute2: upgrade 0.7.10 -> 0.7.12
    applied 9b15d2b71adb... python3-pyyaml-include: upgrade 1.3.2 -> 2.1
    applied 8c2cd2baa264... python3-redis: upgrade 5.0.1 -> 5.0.4
    applied 02120efb4f26... python3-rich: upgrade 13.7.0 -> 13.7.1
    applied 5b9543962bdf... python3-sdbus: upgrade 0.11.1 -> 0.12.0
    applied cdccc4574c98... python3-sh: upgrade 2.0.6 -> 2.0.7
    applied 02bf310317ac... python3-snagboot: upgrade 1.2 -> 1.3
    applied ad0c27b9c43f... python3-stevedore: upgrade 5.1.0 -> 5.2.0
    applied 9c67e15cc5b0... python3-sympy: upgrade 1.12 -> 1.12.1
    applied 9b9c9eed6855... python3-tomlkit: upgrade 0.12.3 -> 0.12.5
    applied 8e70a5212391... python3-typeguard: upgrade 4.2.1 -> 4.3.0
    applied a10146bc6e4a... python3-xlsxwriter: upgrade 3.1.9 -> 3.2.0
    applied 522a26cc2f50... qpdf: upgrade 11.8.0 -> 11.9.0
    applied 04a02df39d48... remmina: upgrade 1.4.34 -> 1.4.35
    applied def9321f39b4... sanlock: upgrade 3.9.2 -> 3.9.3
    applied a0782de16dfe... sdmon: upgrade 0.8.1 -> 0.9.0
    applied 689d3ffffa57... squashfs-tools-ng: upgrade 1.2.0 -> 1.3.1
    applied 653dbf48bb4e... tslib: upgrade 1.22 -> 1.23
    applied a5ec07e2e822... usbredir: upgrade 0.13.0 -> 0.14.0
    applied 3eb7dd257b74... cabextract: add utility to extract Microsft cabinet files
    applied 39d164f0c33d... python3-pydantic-core: Fix build with python 3.12.4
    applied e33270bb821c... xfwm4: fix gcc -Wincompatible-pointer-types
    applied 3b79135ae019... frr: use update-alternatives to solve conflicts with libsmi
    applied 33d4d55b60da... libsmi: use update-alternatives to solve conflicts with frr
    applied e9844b286a81... libblockdev: Add missing dependency on e2fsprogs to fs PACKAGECONFIG.
    applied b528b5a13b8a... libblockdev: Add missing dependency on keyutils to crypto PACKAGECONFIG.
    applied 193aa030f943... python3-whitenoise,python-libusb1: Remove AUTHOR field
    applied 27635c0adcf1... aravis: Remove AUTHOR field
    applied f6f2fad649b2... tnftp: fix lib32-tnftp build failure with gcc-14
    applied 3a819d34c695... smarty: Update status for CVE-2020-10375
    applied 388b8017f9c8... imagemagick: Update status for CVE
    applied 79caf62321ca... nvme-cli: Support read-only systems
    applied d4a7efe3a83a... nss: Upgrade to 3.101 release
    applied 9c7a48afe0a3... giflib: upgrade to version 5.2.2
    applied f58552c01438... trompeloeil: new recipe
    applied e35ce3956a71... mbedtls: Do not set LIB_INSTALL_DIR to an absolute path to make MbedTLSTargets.cmake relocateable.
    applied 96097f84dc35... packagegroup-sdk-target: Drop g77-symlinks
    applied 909908a4516c... libio-compress-perl: Use update alternatives for streamzip and zipdetails
    applied 6b14d0259cfa... fmt: Remove
    applied c2322d2d5a38... lvgl: add gridnav to packageconfig
    applied acefbd2abc02... packagegroup-meta-oe: replace libdbd-mysql-perl with dbd-mariadb
    applied f6949e47758d... re2: rework solibs handling
    applied 9a9c0e6299fd... python3-typer: add new recipe
    applied 7523f0d41c05... hiredis: change ptest output format
    applied 3eb8bf5b5ed5... packagegroup-sdk-target: update runtime dependencies for gfortran
    applied 487a2d569554... exfatprogs: upgrade 1.2.3 -> 1.2.4
poky a88251b3e7 -> 5d88faa0f3:
    applied cc95e57ead78... curl: Backport patch to fix buildtools issues
    applied 25dcc55b74db... bitbake: fetch2/gcp: Add missing runfetchcmd import
    applied f748e07a6321... llvm: upgrade 18.1.2 -> 18.1.3
    applied f15ea3ad06e4... patchtest: test_metadata: fix invalid escape sequences
...