### PR TITLE
subtree update: e5ba6f8e62 -> 51f2f2e947

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -2,19 +2,19 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = master
-last_revision = 03af0c72f13a5455086afc9fa5ed92fa47f29101
+last_revision = 7c2df809e0e27f271cc28b4a2631929985f0c8f7
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = master
-last_revision = 0623501548947e92ffd08625a112b8e7fb17a604
+last_revision = f6352cd450257f9d95865773528eb9c7d0fa026e
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
-last_revision = b58e2af8598037d03cb7d8d9d6bb89a67f474146
+last_revision = 4f934c0ed14e503b97929e362c0103434acd01bc
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
@@ -26,5 +26,5 @@ last_revision = 73077556362fb99520e452cf32501a759125d298
 src_uri = git://git.yoctoproject.org/poky
 dest_dir = poky
 branch = master
-last_revision = c2da016918d1fda5bf63d94b59863f5013e482f9
+last_revision = c49684b48b04e89e40550960558ca18dba3708a5
 


### PR DESCRIPTION
meta-openembedded 0623501548 -> f6352cd450:
    applied 4797b72ba02... python3-lief: Update to tip of master branch
    applied 10c13bf1fbe... mod-dnssd: update SRC_URI
    applied 7bb7493a9bf... libspdm: Fixup the build flags
    applied 7edd553fbc9... bmap-writer: Upgrade to 1.0.2
    applied 6b1ba4543a2... capnproto: remove binaries from target-build, add bbclass
    applied 5a0d4d3e880... protobuf: remove unneeded atomic linker flag
    applied 12c7be0e8a1... protobuf: remove rdepends on abseil-cpp
    applied 300041ab661... jsoncpp: enable nativesdk build
    applied 7bfa5c77f7e... protobuf: use system jsoncpp
    applied c7b6f0a8ce3... protobuf: don't download git submodules
    applied ec554daa6cb... protobuf: add MIT to license
    applied a60b3e2b26d... python3-protobuf: add MIT to license
    applied 30e585a505c... protobuf: set CVE_PRODUCT
    applied ae7556a737f... python3-protobuf: set CVE_PRODUCT
    applied 0063cf8aeef... libeigen: Remove LGPL code
    applied 90bc766bcd4... licenses/MINPACK: Remove
    applied def1bb7c1ee... python3-crc32c: Declare Zlib license
    applied 9d8ef59ebd4... libgpiod: fix ptests failure
    applied 6c176d69c19... python3-gpiod: fix ptest failure
    applied 595f8ae2dc5... sip: Upgrade 6.9.1 -> 6.10.0
    applied 11dae0c22b1... python3-gevent: upgrade 24.2.1 -> 24.11.1
    applied 2b123b1c322... opencv: upgrade 4.10.0 -> 4.11.0
    applied 0bd728bfd9f... openldap: make license match spdx identifier
    applied 766281a2389... spdm-utils: Initial support for spdm-utils
    applied 110992d5109... gjs: Fix install conflict when enable multilib.
    applied 2835bfab941... libatasmart: fix SRC_URI protocol
    applied 4bf0af485f5... mdns: Upgrade 2559.40.32 -> 2559.60.39.0.1
    applied f97bc097f4d... mdns: Correct RPROVIDE to match libdns-sd in avahi
    applied 0ad477bb920... mdns: Separate out mdns-libnss-mdns package
    applied ebcec4a3b4c... python3-lief: Disable ccache
    applied 21230e8d8f9... python3-lief: Disable build on 32bit x86
    applied 0b44d2427ba... python3-lief: Define LIEF_BUILD_DIR as B
    applied 6a37afcb77f... python3-grpcio: drop obsolete variable
    applied 132b2f82f46... python3-grpcio: add patch to allow unbundled build
    applied 3f834832aea... python3-grpcio: use openssl instead of bundled boringssl-with-bazel
    applied 9e141eae00f... python3-grpcio: use system zlib
    applied bd8570dba0e... python3-grpcio: use system c-ares
    applied 3fdbefe915d... python3-grpcio: use system re2
    applied 990b03b6165... python3-grpcio: use system abseil-cpp
    applied 819da5c15d6... python3-grpcio: add missing license
    applied 6630ca8486e... python3-grpcio: add licenses from third party components
    applied 625c74321cd... spectre-meltdown-checker: fix script name
    applied bdbc71f61a8... gphoto: Fix regex to remove --sysroot from CC in config.h
    applied 4ce37f3a0a0... valkey: Upgrade 8.0.1 -> 8.0.2
    applied f02e99377c3... net-snmp: correct typo on RDEPENDS
    applied 83c6dfcce6c... grpc: remove unneeded dependencies
    applied b041e236c0d... grpc: remove workaround for GCC 4.8 in Ubuntu-14.04
    applied ac760128d7f... grpc: fix protobuf-lite package config
    applied c4a6fc8b40f... grpc: add licenses from third party components
    applied c5bec5304bf... gegl: Clean up PACKAGECONFIG
    applied c87c5d5614b... ibus: missing installed file w/ gtk2 PACKAGECONFIG
    applied ba8d9ff050c... gnome-commander: missing dependency for tests PACKAGECONFIG
    applied 9e154ad597c... Update spdm-utils_0.7.2.bb
    applied f0f690a64de... Update libspdm_3.6.0.bb
    applied 6b44831860b... android-tools: drop useless USB_DEBUGGING_ENABLED handling
    applied 2810f145623... android-tools: fix compilation because of include path poisoning
    applied 5f43b108627... phpmyadmin: upgrade 5.2.1 -> 5.2.2
    applied 209495f7e21... opencv: fix build for ppc64
    applied 93772a0fc34... apache2: upgrade 2.4.62 -> 2.4.63
    applied 7c2c125ba18... botan: upgrade 3.6.1 -> 3.7.1
    applied ffeccbc4406... ctags: upgrade 6.1.20250119.0 -> 6.1.20250202.0
    applied 5d75f44b6ff... dool: upgrade 1.3.3 -> 1.3.4
    applied 3322157fda4... flatbuffers: upgrade 24.12.23 -> 25.1.24
    applied db8160c0d9c... gnome-system-monitor: upgrade 47.0 -> 47.1
    applied f1eb45425a3... gparted: upgrade 1.6.0 -> 1.7.0
    applied 7d5d9acb2ab... libdaq: upgrade 3.0.17 -> 3.0.18
    applied def43092808... libjcat: upgrade 0.2.2 -> 0.2.3
    applied c886bab5a06... libmozilla-ca-perl: upgrade 20240924 -> 20250202
    applied a1882f4b179... libmxml: upgrade 4.0.3 -> 4.0.4
    applied e58e457424f... libpaper: upgrade 2.2.5 -> 2.2.6
    applied c1a0ea7669b... libspelling: upgrade 0.4.5 -> 0.4.6
    applied 44845523d7d... libzip: upgrade 1.11.2 -> 1.11.3
    applied 579f5c5f2e3... memcached: upgrade 1.6.34 -> 1.6.36
    applied 40ed18634d2... mpich: upgrade 4.2.3 -> 4.3.0
    applied 7b7083c812d... multipath-tools: upgrade 0.10.0 -> 0.11.0
    applied ccfc9d5a099... mutter: upgrade 47.4 -> 47.5
    applied 4f9f525b0b6... nautilus: upgrade 47.1 -> 47.2
    applied 64426a49285... nss: upgrade 3.107 -> 3.108
    applied 3f185b93b90... osinfo-db: upgrade 20240701 -> 20250124
    applied 35a8cf9e915... parallel: upgrade 20241222 -> 20250122
    applied 209d3e14560... python3-alembic: upgrade 1.14.0 -> 1.14.1
    applied de63fbbfddd... python3-beautifulsoup4: upgrade 4.12.3 -> 4.13.3
    applied a9511c249ba... python3-black: upgrade 24.10.0 -> 25.1.0
    applied f37dd1bb508... python3-cantools: upgrade 40.1.1 -> 40.2.0
    applied 92889796522... python3-cmd2: upgrade 2.5.9 -> 2.5.11
    applied 34ddd26b370... python3-dateparser: upgrade 1.2.0 -> 1.2.1
    applied c9828443aaa... python3-dbus-fast: upgrade 2.30.2 -> 2.33.0
    applied d96b5d36160... python3-deprecated: upgrade 1.2.15 -> 1.2.18
    applied e5eb3d5a04d... python3-eth-utils: upgrade 5.1.0 -> 5.2.0
    applied 70c7d54b4da... python3-evdev: upgrade 1.7.1 -> 1.8.0
    applied 1406c540cd3... python3-eventlet: upgrade 0.37.0 -> 0.39.0
    applied 7dda2a2a74b... python3-executing: upgrade 2.1.0 -> 2.2.0
    applied a77fe5d748d... python3-fsspec: upgrade 2024.12.0 -> 2025.2.0
    applied 6b7b71ff14e... python3-grpcio-channelz: upgrade 1.69.0 -> 1.70.0
    applied 8186353598b... python3-grpcio-reflection: upgrade 1.69.0 -> 1.70.0
    applied f945cda4e7e... python3-grpcio-tools: upgrade 1.69.0 -> 1.70.0
    applied 0097ea7dc75... python3-grpcio: upgrade 1.69.0 -> 1.70.0
    applied e23ab9efbfc... python3-importlib-metadata: upgrade 8.5.0 -> 8.6.1
    applied cea1f979de1... python3-inline-snapshot: upgrade 0.19.3 -> 0.20.1
    applied e6fbaae191b... python3-ipython: upgrade 8.31.0 -> 8.32.0
    applied 9bc0a22e1ac... python3-jdatetime: upgrade 5.1.0 -> 5.2.0
    applied b4aa60319a0... python3-lief: upgrade 0.16.2 -> 0.16.3
    applied 8ef12f84180... python3-lz4: upgrade 4.3.3 -> 4.4.3
    applied 908af5cb26f... python3-marshmallow: upgrade 3.26.0 -> 3.26.1
    applied ab120b8721a... python3-mlcommons-loadgen: upgrade 5.0.5 -> 5.0.14
    applied 67ce7350527... python3-nanobind: upgrade 2.4.0 -> 2.5.0
    applied e22a95f76ed... python3-paramiko: upgrade 3.5.0 -> 3.5.1
    applied 483bcc5100d... python3-pdm: upgrade 2.22.2 -> 2.22.3
    applied ddd5c6e4f4f... python3-prettytable: upgrade 3.12.0 -> 3.14.0
    applied ea6f5e36384... python3-prompt-toolkit: upgrade 3.0.48 -> 3.0.50
    applied 743cf4553cc... python3-pymongo: upgrade 4.10.1 -> 4.11
    applied 6edb22bbe33... python3-pyparted: upgrade 3.12.0 -> 3.13.0
    applied 9c86ed0f4b2... python3-pytest-lazy-fixtures: upgrade 1.1.1 -> 1.1.2
    applied 15cc0df46f2... python3-qface: upgrade 2.0.11 -> 2.0.12
    applied 98afc6ab405... python3-rlp: upgrade 4.0.1 -> 4.1.0
    applied a6d478627cb... python3-starlette: upgrade 0.45.2 -> 0.45.3
    applied 573843f94c0... python3-twine: upgrade 6.0.1 -> 6.1.0
    applied 68cd2c1f3f6... python3-tzdata: upgrade 2024.2 -> 2025.1
    applied 4f9a3f73867... python3-web3: upgrade 7.7.0 -> 7.8.0
    applied a6d9afe38ed... python3-xlsxwriter: upgrade 3.2.0 -> 3.2.1
    applied 68899200e30... python3-zeroconf: upgrade 0.141.0 -> 0.143.0
    applied c5199e0925c... smarty: update 5.4.2 -> 5.4.3
    applied efc0b522c15... nmap: fix racing issue at do_compile
    applied f7aa588db9a... folks: add missing dependency
    applied 747f2b282b3... mozjs-128: keep persistent state directory in WORKDIR
    applied 8296482ab0d... grilo: remove obsolete comment
    applied 5964bd5397c... python3-aiohttp: Upgrade 3.11.11 -> 3.11.12
    applied c7a1c55f267... python3-aiohappyeyeballs: Upgrade 2.4.4 -> 2.4.6
    applied c91033bdc08... python3-semver: Upgrade 3.0.2 -> 3.0.4
    applied 40682626c3b... python3-soupsieve: Add missing rdep on python3-typing-extensions for ptests
    applied d54a6102d81... android-tools: build without gold
    applied 4b07ca12ff3... python3-pymodbus: Upgrade 3.8.3 -> 3.8.6
    applied bd71da1a72a... python3-python-vlc: Upgrade 3.0.2012 -> 3.0.21203
    applied 482abb2a654... python3-tomli-w: Upgrade 1.1.0 -> 1.2.0
    applied 01a52551ba2... python3-gpiod: update to v2.2.4
    applied 7aa6bbb1e14... python3-typer: Ignore failing ptests
    applied 7e8b47ccc64... networkmanager: remove nmtui from EXTRA_OEMESON
    applied ead8f7b3273... mutter: fix profiler PACKAGECONFIG
    applied d390ea77667... python3-google-auth: Disable TestDecryptPrivateKey ptest
    applied b815bcc2344... gegl: update 0.4.52 -> 0.4.54
    applied 74c7e41978f... xmlsec1: upgrade 1.3.5 -> 1.3.7
    applied 1587704e45f... wireshark: upgrade 4.2.9 -> 4.2.10
    applied 2acc4af5d0b... python3-pydantic: Upgrade 2.10.5 -> 2.10.6
    applied e6001459280... python3-git-pw: Upgrade 2.7.0 -> 2.7.1
    applied da93aafcc54... python3-whitenoise: Upgrade 6.8.2 -> 6.9.0
    applied 313acb4788f... python3-pylint: Upgrade 3.3.3 -> 3.3.4
    skipped f6352cd4502... libspdm: add support for ppc64le
meta-arm 03af0c72f1 -> 7c2df809e0:
    applied 34d326f1079... systemd-boot: update systemd-bootaarch64.efi path
    applied d6562758554... arm-bsp/u-boot: corstone1000: Reserve memory for RSS comm pointer access protocol
    applied f0f0be29a3c... arm/trusted-firmware-a: Add cot-dt2c
    applied 8a457932df1... arm/trusted-firmware-a: Move 2.11 to meta-arm-bsp
    applied 5773030601c... CI/machine-summary: remove binary toolchains and sort entries alphabetically
    applied 7c2df809e0e... arm/trusted-firmware-a: move qemuarm64-secureboot file to the correct location
meta-raspberrypi b58e2af859 -> 4f934c0ed1:
    applied 51f06365f36... raspberrypi5.conf: Add CM5 dtb's
    applied 810f1a23958... rpi-base: Fix CM5 boot panic
    applied 4f934c0ed14... linux-raspberrypi: add recipe for 6.12
poky c2da016918 -> c49684b48b:
    applied b65452bda3ca... bitbake: parse: Forbid ambiguous assignments to ${.}, ${+}, and ${:} variables
    applied d06ed534351a... alsa-utils: Backport fix for alsa_restore_go/std
    applied 7b59d11d012d... docbook-xsl-stylesheets: Use SPDX identifier
    applied bf76c0aa98e2... hwdata: Use SPDX identifier
    applied bdcc24a44faa... licenses: Map SGIv1 to SGI-OpenGL
    applied 0b764138912b... tcf-agent: Use SPDX identifier
    applied 1f96cd3d1764... unfs3: Use SPDX identifier
    applied aab0fdf3b74f... systemd-systemctl: fix handling of instance unit files
    applied e4e77b1f374f... linux-firmware: split the qca6390 firmware
    applied 7a42e31654a3... nss-mdns: Rename recipe to avahi-libnss-mdns
    applied f16992eb568c... avahi: Switch RRECOMMENDS to avahi-libnss-mdns
    applied c8dda4c735fc... lib/oe/sbom30: Fix SHA256 hash dictionary
    applied 9600cd875b2f... spdx30: Include files in rootfs
    applied ff1303ed467b... linux-firmware: Add RTL8723DS blobs into ${PN}-rtl8723
    applied a86627cffa8a... systemd-serialgetty: add comments explaining use
    applied 1fb9f1684fa1... at-spi2-core: upgrade 2.54.0 -> 2.54.1
    applied e96c282f4720... bind: upgrade 9.20.4 -> 9.20.5
    applied d0dc1499a9f7... diffoscope: upgrade 284 -> 287
    applied e6eb0cebbcb7... epiphany: upgrade 47.2 -> 47.3.1
    applied 30fcae3329f3... git: upgrade 2.47.1 -> 2.48.1
    applied 64afd472d201... gnupg: upgrade 2.5.2 -> 2.5.3
    applied 6a1655d2704a... gst-devtools: upgrade 1.24.10 -> 1.24.12
    applied 0a84589db9f4... gstreamer1.0-libav: upgrade 1.24.10 -> 1.24.12
    applied e009e332d288... gstreamer1.0-plugins-{bad,ugly,base,good,rtsp-server}: upgrade 1.24.10 -> 1.24.12
    applied c231417610d1... gstreamer1.0-python: upgrade 1.24.10 -> 1.24.12
    applied 925d5f1c725c... gstreamer1.0: upgrade 1.24.10 -> 1.24.12
    applied 1648db00b9d5... gstreamer1.0-vaapi: upgrade 1.24.10 -> 1.24.12
    applied a89745e1ba94... harfbuzz: upgrade 10.1.0 -> 10.2.0
    applied 9677c7464d62... iproute2: upgrade 6.12.0 -> 6.13.0
    applied 1e7ead38a05e... libexif: upgrade 0.6.24 -> 0.6.25
    applied 59ec0e13e7ed... libinput: upgrade 1.27.0 -> 1.27.1
    applied 7297d3ac6a15... libslirp: upgrade 4.8.0 -> 4.9.0
    applied b38f168bf3ae... libsoup: upgrade 3.6.1 -> 3.6.4
    applied f2a5ac6775d8... libwpe: upgrade 1.16.0 -> 1.16.1
    applied 90b7b65664b3... lighttpd: upgrade 1.4.76 -> 1.4.77
    applied 211e3774e792... lzlib: upgrade 1.14 -> 1.15
    applied c6e9b288f4e7... mc: upgrade 4.8.32 -> 4.8.33
    applied 101c74bd9240... mmc-utils: upgrade to latest revision
    applied fb9a52f9dedb... msmtp: upgrade 1.8.27 -> 1.8.28
    applied 02c58603d96a... mtools: upgrade 4.0.46 -> 4.0.47
    applied 57b034e0c24a... piglit: upgrade to latest revision
    applied 56a04d1346d3... python3-attrs: upgrade 24.3.0 -> 25.1.0
    applied ec6c0697eb0d... python3-certifi: upgrade 2024.12.14 -> 2025.1.31
    applied da838310f8ee... python3-hypothesis: upgrade 6.123.2 -> 6.124.7
    applied 9b692120a3e9... python3-license-expression: upgrade 30.4.0 -> 30.4.1
    applied 4811f1fa484e... python3-more-itertools: upgrade 10.5.0 -> 10.6.0
    applied 2f8c7500d783... python3-pip: upgrade 24.3.1 -> 25.0
    applied f6b35ad25e92... python3-poetry-core: upgrade 2.0.0 -> 2.0.1
    applied 50b8dead36c8... python3-pygments: upgrade 2.19.0 -> 2.19.1
    applied 1c88bc1fe3ba... python3-pyopenssl: upgrade 24.3.0 -> 25.0.0
    applied 8ded6b92578d... python3-pytz: upgrade 2024.2 -> 2025.1
    applied 0b102f6cbe85... python3-referencing: upgrade 0.35.1 -> 0.36.2
    applied 7e927835e8e7... python3-ruamel-yaml: upgrade 0.18.9 -> 0.18.10
    applied 2eab360fb2e0... python3-setuptools: upgrade 75.6.0 -> 75.8.0
    applied dd0bea4a9657... python3-trove-classifiers: upgrade 2024.10.21.16 -> 2025.1.15.22
    applied ba6d1c6ba245... python3-websockets: upgrade 14.1 -> 14.2
    applied 8d41a98324c3... repo: upgrade 2.50.1 -> 2.51
    applied 6e9e3997ab7b... stress-ng: upgrade 0.18.08 -> 0.18.09
    applied dc0ded89ea3b... sysklogd: upgrade 2.6.2 -> 2.7.0
    applied f710bb8df2a8... wayland-protocols: upgrade 1.39 -> 1.40
    applied 64dd41cbc21a... cmake: upgrade 3.31.4 -> 3.31.5
    applied 7741a3aa073a... llvm: upgrade 19.1.6 -> 19.1.7
    applied 4e18df274c58... ed: upgrade 1.20.2 -> 1.21
    applied 60611f996e43... libpng: upgrade 1.6.44 -> 1.6.45
    applied fedeaf1b5378... lzip: upgrade 1.24.1 -> 1.25
    applied d16b82e7cad6... python3-rdflib: upgrade 7.1.1 -> 7.1.3
    applied 908be6fd24fb... testimage.bbclass: fix logDetails() call on error path
    applied d1f0bbb96240... xorg-minimal-fonts: dont try to install builddir
    applied 7c65f1da1753... binutils: Upgrade to 2.44 release
    applied 69b2211f5811... gdb: Upgrade to 16.2 relese
    applied 882eb41e1777... qemuriscv: Enable Sv39 memory address scheme by default
    applied 619c5c1185da... valgrind: update 3.23.0 -> 3.24.0 (ptest fails, vg_regtest needs rebase)
    applied 2b62eb2c5865... valgrind: disable ptests
    applied 2673221ea588... ptest-packagelists: remove valgrind
    applied 123f8e78f30a... glibc: Upgrade to 2.41 release
    applied 41aab515a764... selftest/reproducible: Move a comment to follow the line it concerns
    applied 50a609576e39... selftest/reproducible: Add a method to test a single recipe
    applied de55387976a7... README.OE-Core.md: fix markdown style issues
    applied 7c3b3019ea03... MAINTAINERS.md: fix markdown style issues
    applied f263e0f5e2ea... README.qemu.md: fix markdown style issues
    applied bc175290e634... SECURITY.md: fix markdown style issues
    applied e8d4c8a15369... patchtest/README.md: fix markdown style issues
    applied fe0669477e62... rust/README-rust.md: fix markdown style issues
    applied ce5428f48a5f... rust: restore parallel builds, disable lto only for rustdoc
    applied 7e55fd135f22... libseccomp: Upgrade 2.5.5 -> 2.6
    applied 10dce263f023... meta: Enable '-o pipefail' for the SDK installer
    applied 4f60c1d0293e... python3: Fix typo in python3-manifest.json
    applied 1141e202e771... python3: Fix typo in create_manifest3.py
    applied 069a3460360e... perl: fix do_install failed for nativesdk-perl
    applied 64ef07f6c4ad... bitbake: b4-config: Add basic support for b4 contribution workflow
    applied 0698d606be1a... scripts: add b4-wrapper for poky
    applied 65e773f88b78... b4-config: Add basic support for b4 contribution workflow
    applied cfb975c62e5b... Revert "selftest/sstatetests: run CDN mirror check only once"
    applied afb9ac9181b1... documentation: Fix typo in standards.md
    applied d554399bf8d5... release-notes-5.2: add information about rpm and sequoia
    applied 21521c621895... dev-manual/packages: add information about signing changes
    applied cfe5da1f75e7... Move devtool doc from extensible to dev manual
    applied 6fd46f2e8715... dev-manual/devtool: remove reference to the extensible SDK
    applied 0eb974d9720a... ref-manual/faq: add q&a on systemd as default
    applied 42957c5c2557... ref-manual: Describe grub-efi-cfg overrides and GRUB_TITLE
    applied a65594c2b5fb... migration-guides: add release notes for 4.0.24
    applied 4e4996855fe9... migration-guides: add release notes for 5.1.2
    applied 8c49710b8d54... migration-5.2: document BB_CURRENT_MC default value change
    applied cf616cbae719... migration-5.2: add virtual provider change
    applied e0a7a6eb096d... lib/oeqa/metadata: Add commit_time to branch metadata being saved
    applied 9f3127060027... scripts/buildperf: Add chart tabs for commit count/time
    applied f91a2072c956... go: Fix to work without gold on aarch64
    applied 6d0cf6477c17... go: upgrade 1.22.11 -> 1.22.12
    applied 89ce67d8e41c... recipes: Drop ld-is-gold support
    applied a9f345c9aeec... nfs-utils: remove python hashbang rewrites
    applied fca4f4f712f5... openssl: fix register trampling on aarch64
    applied c4a4cc8b6a81... libslirp: set the PV in the filename
    applied f82bac5b5a4c... rpm: add PACKAGECONFIG dependencies
    applied 39cbbd1a8766... classes: switch p7zip to 7zip
    applied 5a2a26392907... documentation.conf: Add description for IMAGE_ROOTFS_MAXSIZE variable
    applied 371ecef31872... uboot-config: Fix devtool modify
    applied 29bccf5ae13d... systemd-boot-native: move do_install() to after do_patch()
    applied a47637f7c0d3... uki.bbclass: capture ukify command stdout and stderr
    applied 3582905ff996... systemd-boot-native: fix kernel signature for secureboot
    applied f555c53c1eb4... uki.bbclass: remove duplicate d.getVar('DEPLOY_DIR_IMAGE')
    applied 78d0ba12efdd... dbus: explictly set the path to systemctl
    applied 73b287b434e6... mpfr: Fix build with glibc 2.41
    applied 2f816f756b84... cmake: apply parallel build settings to ptest tasks
    applied 10870db53360... wic: bootimg-efi: Support + symbol in filenames
    applied f7174e591f6b... curl: upgrade 8.11.1 -> 8.12.0
    applied fe5eb41c4cde... python3-typogrify: upgrade 2.0.7 -> 2.1.0
    applied a886f0a8cdb4... liburcu: add missing header file in uatomic/generic.h
    applied 31a537d12441... b4-wrapper-poky.py: send changes to .b4-config to the poky mailing list
    applied 0bf496f24b4b... python3-cffi: Fix failing ptests with clang
    applied 7013a9ed0667... python3: upgrade 3.13.1 -> 3.13.2
    applied 5346f1fecbf9... kernel: drop 6.6 reference kernels
    applied c8983084b37a... kernel: remove unused 6.10 CVE exclusion file
    applied b8e369ef6123... linux-yocto/6.12: update to v6.12.12
    applied 5b23b6d29e36... linux-yocto/6.12: update to v6.12.13
    applied 0a20b836bd61... linux-firmware: further split qca61x4 package
    applied df8f1ad5ccf5... python3-bcrypt: fix ptest
    applied 68bbc11f8f84... kernel-fitimage.bbclass: introduce FIT_UBOOT_ENV
    applied 9ea3f0e4cdaa... kernel-fitimage.bbclass: do not use the UBOOT_ENV variable
    applied d29786839f08... oe-selftest: fitimage split run_dumpimage function
    applied 4558f1b7220a... oe-selftest: fitimage add u-boot env script
    applied 59dd1cdba644... libsecret: upgrade 0.21.4 -> 0.21.6
    applied 723bb4240ae8... libsecret: Inherit bash-completion
    applied a24b1786664c... oe-build-perf-report: Use commit_time if available
    applied 261a1409b1da... oeqa/runtime: Add debugging if networking fails
    applied 5c8705b48348... script/relocate_sdk.py: check dynamic loader arch before relocating interpreter
    applied 4ed99ca9b4a9... toolchain-shar-relocate.sh: support multiple dynamic loaders for multilib
    applied 2fb5d93afb78... kernel-fitImage: Take possible multiconfig into account.
    applied eb1537f04b4f... kernel-fitImage: Remove dependeny on initramfs image when bundled.
    applied c0329693b160... ncurses: Fix install conflict when enable multilib.
    applied c30f3ec853d0... meson.bbclass: Add an option to specify install tags
    applied 0b07f6d0dee7... libxkbcommon: convert to git
    applied b9dbb45aa636... package_ipk: Use preferred form of --force-postinstall
    applied eced0341cc58... genericarm64.conf: allow overriding u-boot and qemuboot variables
    applied bf6fae9619b7... poky-alt: switch preferred kernel to 6.12
    applied 33cfb14214dd... yocto-bsp: drop linux-yocto 6.6 bbappend
    applied 2b71696f35ec... bitbake: fetch2: do not decode user from file URI
    applied e69304675db4... bitbake: tests: fetch: add test for file URI with @
    applied 34bb313e903f... bitbake: tests: fetch: use lower case hostnames
    applied 851b24cf818e... bitbake: tests: fetch: quote URI password as per RFC3986
    applied 2935d76bb468... bitbake: fetch2: remove duplicated code in url decode and encode
    applied 3e543e8eaa18... bitbake: fetch2: remove unnecessary expand function calls
    applied f17c51c6959f... bitbake: fetch2: local: use path variable
    applied 170dd77e4af6... bitbake: fetch2: remove unnecessary unquote
    applied f62042523a0f... bitbake: fetch2: ssh: use common localpath handling
    applied c49684b48b04... bitbake: fetch2: clearcase: remove double DL_DIR from localfile

openbmc-subtree update -c master.conf -t openbmc -sxa --subtree poky \
    --subtree meta-openembedded --subtree meta-security --subtree \
    meta-raspberrypi --subtree meta-arm --shortlog
