### PR TITLE
split and move layers for poky deprecation

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -1,30 +1,41 @@
 [meta-arm]
 src_uri = git://git.yoctoproject.org/meta-arm
-dest_dir = meta-arm
+dest_dir = upstream-layers/meta-arm
 branch = master
 last_revision = f9b3ee441577ff3d99230a57620d36c1e7f049fe
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded
-dest_dir = meta-openembedded
+dest_dir = upstream-layers/meta-openembedded
 branch = master
 last_revision = 2de5071f9ac17338ea8a0ec0bbd451c5455166e9
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
-dest_dir = meta-raspberrypi
+dest_dir = upstream-layers/meta-raspberrypi
 branch = master
 last_revision = 03981f936553e9394db4133139c2083dbc4b7cb0
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security
-dest_dir = meta-security
+dest_dir = upstream-layers/meta-security
 branch = master
 last_revision = 06bd60600e8db1b843cf5cc0f074a11eac7e9a80
 
-[poky]
-src_uri = git://git.yoctoproject.org/poky
-dest_dir = poky
+[openembedded-core]
+src_uri = git://git.yoctoproject.org/openembedded-core
+dest_dir = upstream-layers/openembedded-core
 branch = master
-last_revision = 921c46de4fb36e02c29369f6d3066a622c7d51f7
+last_revision = a59b385184fb3a548dc27310fd04d64351d8dfba
 
+[bitbake]
+src_uri = git://git.openembedded.org/bitbake
+dest_dir = upstream-layers/bitbake
+branch = master
+last_revision = 5ba7c2f0797a72536a81f57276d4e5c75f23011c
+
+[yocto-docs]
+src_uri = git://git.yoctoproject.org/yocto-docs
+dest_dir = upstream-layers/yocto-docs
+branch = master
+last_revision = f9f1c87424d307d2df60024bc448bd6778605cf8


### PR DESCRIPTION
Poky as a layer is now deprecated and we need to get content from
various split sub-layers.  Add the config here to match what has
been done in the openbmc repository.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
