### PR TITLE
upstream update for 2026-03-12

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -26,7 +26,7 @@ last_revision = 9e6d962250aab6e5319215f15b0201ef233c46cd
 src_uri = git://git.openembedded.org/openembedded-core
 dest_dir = upstream-layers/openembedded-core
 branch = master
-last_revision = a59b385184fb3a548dc27310fd04d64351d8dfba
+last_revision = 7e75ec7a66c8c5f06c264784b0b6daaca37a9381
 
 [bitbake]
 src_uri = git://git.openembedded.org/bitbake

--- a/master.conf
+++ b/master.conf
@@ -8,7 +8,7 @@ last_revision = 6182cec88cc5d177726d56d7fcea9f80e8f2786b
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = upstream-layers/meta-openembedded
 branch = master
-last_revision = 2de5071f9ac17338ea8a0ec0bbd451c5455166e9
+last_revision = 0bc67b61ca52e85a5a882d809ba0c98d21cceac8
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi


### PR DESCRIPTION
- **split and move layers for poky deprecation**
- **subtree update: ca0204dda6 -> 46364d45eb**
- **subtree update: 46364d45eb -> df6b03ae4e**
- **subtree update: df6b03ae4e -> 52b2aad978**
- **subtree update: 52b2aad978 -> 1a37629a49**
- **subtree update: 1a37629a49 -> 3163037bbc**
- **fix openembedded-core URI**
- **subtree update: 3163037bbc -> e72c4c6644**
- **subtree update: e72c4c6644 -> 9ac16886ec**
