### PR TITLE
yocto update 2026-03-28

### DIFF
--- a/master.conf
+++ b/master.conf
@@ -38,5 +38,5 @@ last_revision = 64fda8cb8efaff280d33bf60d93fed6e37244640
 src_uri = git://git.yoctoproject.org/yocto-docs
 dest_dir = upstream-layers/yocto-docs
 branch = master
-last_revision = d97cfeaa55ed42722998d3313c1857aa377f6881
+last_revision = 5bfe4f9aecf542766dec727bedbb30b1f93ab64a
 

--- a/master.conf
+++ b/master.conf
@@ -20,7 +20,7 @@ last_revision = 9720dc611cf38ff2990bdf0f6afa106645ca1f93
 src_uri = git://git.yoctoproject.org/meta-security
 dest_dir = upstream-layers/meta-security
 branch = master
-last_revision = 9e6d962250aab6e5319215f15b0201ef233c46cd
+last_revision = 8028c573db6923525c2918724f2bd36d4a420e0b
 
 [openembedded-core]
 src_uri = git://git.openembedded.org/openembedded-core

--- a/master.conf
+++ b/master.conf
@@ -2,7 +2,7 @@
 src_uri = git://git.yoctoproject.org/meta-arm
 dest_dir = upstream-layers/meta-arm
 branch = master
-last_revision = 6182cec88cc5d177726d56d7fcea9f80e8f2786b
+last_revision = 1778b36d666e5c990778bac8abe503175149b451
 
 [meta-openembedded]
 src_uri = git://git.openembedded.org/meta-openembedded

--- a/master.conf
+++ b/master.conf
@@ -14,7 +14,7 @@ last_revision = 0bc67b61ca52e85a5a882d809ba0c98d21cceac8
 src_uri = git://git.yoctoproject.org/meta-raspberrypi
 dest_dir = upstream-layers/meta-raspberrypi
 branch = master
-last_revision = 046a23892770accf32776bd16a2bf6ad534f42eb
+last_revision = 9720dc611cf38ff2990bdf0f6afa106645ca1f93
 
 [meta-security]
 src_uri = git://git.yoctoproject.org/meta-security

--- a/master.conf
+++ b/master.conf
@@ -32,7 +32,7 @@ last_revision = 7e75ec7a66c8c5f06c264784b0b6daaca37a9381
 src_uri = git://git.openembedded.org/bitbake
 dest_dir = upstream-layers/bitbake
 branch = master
-last_revision = b59bdcf8134e6f5935e8f7b0ed8033cbb745e0ff
+last_revision = 64fda8cb8efaff280d33bf60d93fed6e37244640
 
 [yocto-docs]
 src_uri = git://git.yoctoproject.org/yocto-docs

--- a/master.conf
+++ b/master.conf
@@ -26,7 +26,7 @@ last_revision = 8028c573db6923525c2918724f2bd36d4a420e0b
 src_uri = git://git.openembedded.org/openembedded-core
 dest_dir = upstream-layers/openembedded-core
 branch = master
-last_revision = 7e75ec7a66c8c5f06c264784b0b6daaca37a9381
+last_revision = b50d6debf7baa555fbfb3521c4f952675bba2d37
 
 [bitbake]
 src_uri = git://git.openembedded.org/bitbake

--- a/master.conf
+++ b/master.conf
@@ -8,7 +8,7 @@ last_revision = 1778b36d666e5c990778bac8abe503175149b451
 src_uri = git://git.openembedded.org/meta-openembedded
 dest_dir = upstream-layers/meta-openembedded
 branch = master
-last_revision = 0bc67b61ca52e85a5a882d809ba0c98d21cceac8
+last_revision = c3c094cf8d8df28c7db0f44890e092aee395cb99
 
 [meta-raspberrypi]
 src_uri = git://git.yoctoproject.org/meta-raspberrypi


### PR DESCRIPTION
- **subtree update: 1a37629a49 -> 3163037bbc**
- **subtree update: 3163037bbc -> e72c4c6644**
- **bitbake: subtree update: 9924d5a91b -> a25752a624**
- **meta-arm: subtree update: a25752a624 -> 5b2b1ebc95**
- **meta-raspberrypi: subtree update: 5b2b1ebc95 -> 5b47a977f4**
- **meta-security: subtree update: 5b47a977f4 -> 25438c06c2**
- **meta-openembedded: subtree update: 25438c06c2 -> bec7770273**
- **openembedded-core: subtree update: bec7770273 -> 831de341a6**
- **yocto-docs: subtree update: 831de341a6 -> ae2a6f4990**
