### PR TITLE
openbmc-subtree: fix exit code

### DIFF
--- a/openbmc-subtree
+++ b/openbmc-subtree
@@ -597,4 +597,4 @@ subtree.conf.'''
 
 
 if __name__ == '__main__':
-    sys.exit(0 if main() else 1)
+    main()


### PR DESCRIPTION
The previous logic always ended up failing the script with an `exit 1`.
This was because it was checking the return of main, which has no
return, so the return was always None (which is falsy).  All of the
functions call `sys.exit` directly when failing, so we do not need a
top-level check of status.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
