### PR TITLE
wrynose: bitbake: roll back to 2.18 branch

### DIFF
--- a/wrynose.conf
+++ b/wrynose.conf
@@ -31,8 +31,8 @@ last_revision = 42fa856a00ac16b2a7a83d7ecfa60a5be192b16c
 [bitbake]
 src_uri = git://git.openembedded.org/bitbake
 dest_dir = upstream-layers/bitbake
-branch = master
-last_revision = 941cfe74c19e01e977101e95b09425d21faf844d
+branch = 2.18
+last_revision = a82590d57b17e797575deb27ed29097d8713c9fa
 
 [yocto-docs]
 src_uri = git://git.yoctoproject.org/yocto-docs


### PR DESCRIPTION
The wrynose release should be on the 2.18 branch.  We had one
commit picked up from 2.19 in our master branch, which has been
reverted in the openbmc wrynose branch.  Explicitly set the branch
to 2.18 for bitbake so future subtree updates do the right thing.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
