### PR TITLE
use https endpoints

### DIFF
--- a/kirkstone.conf
+++ b/kirkstone.conf
@@ -1,23 +1,23 @@
 [meta-openembedded]
-src_uri = git://git.openembedded.org/meta-openembedded
+src_uri = https://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = kirkstone
 last_revision = f95484417e3d3e65ca15b460ba71dfd35773f0e4
 
 [meta-raspberrypi]
-src_uri = git://git.yoctoproject.org/meta-raspberrypi
+src_uri = https://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = kirkstone
 last_revision = 43683cb14b6afc144619335b3a2353b70762ff3e
 
 [meta-security]
-src_uri = git://git.yoctoproject.org/meta-security
+src_uri = https://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = kirkstone
 last_revision = d398cc6ea6716afd3a3a6e88ad8fbdc89510ef23
 
 [poky]
-src_uri = git://git.yoctoproject.org/poky
+src_uri = https://git.yoctoproject.org/poky
 dest_dir = poky
 branch = kirkstone
 last_revision = 43b94d2b8496eae6e512c6deb291b5908b7ada47

--- a/master.conf
+++ b/master.conf
@@ -1,41 +1,41 @@
 [meta-arm]
-src_uri = git://git.yoctoproject.org/meta-arm
+src_uri = https://git.yoctoproject.org/meta-arm
 dest_dir = upstream-layers/meta-arm
 branch = master
 last_revision = 8eb10af8092dc3fff86891339fd024d8583f457f
 
 [meta-openembedded]
-src_uri = git://git.openembedded.org/meta-openembedded
+src_uri = https://git.openembedded.org/meta-openembedded
 dest_dir = upstream-layers/meta-openembedded
 branch = master
 last_revision = 76700b6eaf327bb30e2c47b78713e2e409cfab7c
 
 [meta-raspberrypi]
-src_uri = git://git.yoctoproject.org/meta-raspberrypi
+src_uri = https://git.yoctoproject.org/meta-raspberrypi
 dest_dir = upstream-layers/meta-raspberrypi
 branch = master
 last_revision = b83766291188efb956c475b09c9666c2dfe2cb69
 
 [meta-security]
-src_uri = git://git.yoctoproject.org/meta-security
+src_uri = https://git.yoctoproject.org/meta-security
 dest_dir = upstream-layers/meta-security
 branch = master
 last_revision = bd6927e1dfc19b2b9619da85e03fb06b6fb6dc03
 
 [openembedded-core]
-src_uri = git://git.openembedded.org/openembedded-core
+src_uri = https://git.openembedded.org/openembedded-core
 dest_dir = upstream-layers/openembedded-core
 branch = master
 last_revision = 42fa856a00ac16b2a7a83d7ecfa60a5be192b16c
 
 [bitbake]
-src_uri = git://git.openembedded.org/bitbake
+src_uri = https://git.openembedded.org/bitbake
 dest_dir = upstream-layers/bitbake
 branch = master
 last_revision = 941cfe74c19e01e977101e95b09425d21faf844d
 
 [yocto-docs]
-src_uri = git://git.yoctoproject.org/yocto-docs
+src_uri = https://git.yoctoproject.org/yocto-docs
 dest_dir = upstream-layers/yocto-docs
 branch = master
 last_revision = eb74fdfd9e5e579a65e8872d1a73b51e77b14f63

--- a/nanbield.conf
+++ b/nanbield.conf
@@ -1,29 +1,29 @@
 [meta-arm]
-src_uri = git://git.yoctoproject.org/meta-arm
+src_uri = https://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = nanbield
 last_revision = 150169d01f2f57dcd65854a2a43aebef87ee8d98
 
 [meta-openembedded]
-src_uri = git://git.openembedded.org/meta-openembedded
+src_uri = https://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = nanbield
 last_revision = da9063bdfbe130f424ba487f167da68e0ce90e7d
 
 [meta-raspberrypi]
-src_uri = git://git.yoctoproject.org/meta-raspberrypi
+src_uri = https://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = nanbield
 last_revision = fd79e74cbc112aca09c449b80aaa076a21f99ef5
 
 [meta-security]
-src_uri = git://git.yoctoproject.org/meta-security
+src_uri = https://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = nanbield
 last_revision = 5938fa58396968cc6412b398d403e37da5b27fce
 
 [poky]
-src_uri = git://git.yoctoproject.org/poky
+src_uri = https://git.yoctoproject.org/poky
 dest_dir = poky
 branch = nanbield
 last_revision = 7b8aa378d069ee31373f22caba3bd7fc7863f447

--- a/scarthgap.conf
+++ b/scarthgap.conf
@@ -1,29 +1,29 @@
 [meta-arm]
-src_uri = git://git.yoctoproject.org/meta-arm
+src_uri = https://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = scarthgap
 last_revision = 0f1e7bf92c89759f0ab74cfa5be4ee47b092ad46
 
 [meta-openembedded]
-src_uri = git://git.openembedded.org/meta-openembedded
+src_uri = https://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = scarthgap
 last_revision = 15e18246dd0c0585cd1515a0be8ee5e2016d1329
 
 [meta-raspberrypi]
-src_uri = git://git.yoctoproject.org/meta-raspberrypi
+src_uri = https://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = scarthgap
 last_revision = 8767e2ff80ec3b09cd70dd22cdb18e783ab20d7b
 
 [meta-security]
-src_uri = git://git.yoctoproject.org/meta-security
+src_uri = https://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = scarthgap
 last_revision = bc865c5276c2ab4031229916e8d7c20148dfbac3
 
 [poky]
-src_uri = git://git.yoctoproject.org/poky
+src_uri = https://git.yoctoproject.org/poky
 dest_dir = poky
 branch = scarthgap
 last_revision = c4a4df3e720e2d8a3dd2c2a0467704a42b468205

--- a/styhead.conf
+++ b/styhead.conf
@@ -1,29 +1,29 @@
 [meta-arm]
-src_uri = git://git.yoctoproject.org/meta-arm
+src_uri = https://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = styhead
 last_revision = 18bc3f9389907f805b0a8ad4b6543bbdd0274d5e
 
 [meta-openembedded]
-src_uri = git://git.openembedded.org/meta-openembedded
+src_uri = https://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = styhead
 last_revision = 5d54a52fbeb69dba7b8ae11db98af4813951fa61
 
 [meta-raspberrypi]
-src_uri = git://git.yoctoproject.org/meta-raspberrypi
+src_uri = https://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
 last_revision = 97d7a6b5ec09ee85d96e1ec4cabcaa5b24a805f3
 
 [meta-security]
-src_uri = git://git.yoctoproject.org/meta-security
+src_uri = https://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = styhead
 last_revision = e2c44c8b5d02591ec0be3266d6667e16725bcb92
 
 [poky]
-src_uri = git://git.yoctoproject.org/poky
+src_uri = https://git.yoctoproject.org/poky
 dest_dir = poky
 branch = styhead
 last_revision = ecd195a3ef96b7d1b41344e6399bfae60483a6c8

--- a/walnascar.conf
+++ b/walnascar.conf
@@ -1,29 +1,29 @@
 [meta-arm]
-src_uri = git://git.yoctoproject.org/meta-arm
+src_uri = https://git.yoctoproject.org/meta-arm
 dest_dir = meta-arm
 branch = walnascar
 last_revision = 4f8d2f4b2fa23b89098a8e7347d6bb26228acd68
 
 [meta-openembedded]
-src_uri = git://git.openembedded.org/meta-openembedded
+src_uri = https://git.openembedded.org/meta-openembedded
 dest_dir = meta-openembedded
 branch = walnascar
 last_revision = 2169c9afcc0945045bea49f58011080942d4ddb4
 
 [meta-raspberrypi]
-src_uri = git://git.yoctoproject.org/meta-raspberrypi
+src_uri = https://git.yoctoproject.org/meta-raspberrypi
 dest_dir = meta-raspberrypi
 branch = master
 last_revision = c489c75260fea5877b079a0045513ce3b2b7483c
 
 [meta-security]
-src_uri = git://git.yoctoproject.org/meta-security
+src_uri = https://git.yoctoproject.org/meta-security
 dest_dir = meta-security
 branch = walnascar
 last_revision = 784ca4b6584101e971b2d5d76ec7b716ad1301b5
 
 [poky]
-src_uri = git://git.yoctoproject.org/poky
+src_uri = https://git.yoctoproject.org/poky
 dest_dir = poky
 branch = walnascar
 last_revision = fd9b605507a20d850a9991316cd190c1d20dc4a6

--- a/wrynose.conf
+++ b/wrynose.conf
@@ -1,41 +1,41 @@
 [meta-arm]
-src_uri = git://git.yoctoproject.org/meta-arm
+src_uri = https://git.yoctoproject.org/meta-arm
 dest_dir = upstream-layers/meta-arm
 branch = master
 last_revision = 8eb10af8092dc3fff86891339fd024d8583f457f
 
 [meta-openembedded]
-src_uri = git://git.openembedded.org/meta-openembedded
+src_uri = https://git.openembedded.org/meta-openembedded
 dest_dir = upstream-layers/meta-openembedded
 branch = master
 last_revision = 76700b6eaf327bb30e2c47b78713e2e409cfab7c
 
 [meta-raspberrypi]
-src_uri = git://git.yoctoproject.org/meta-raspberrypi
+src_uri = https://git.yoctoproject.org/meta-raspberrypi
 dest_dir = upstream-layers/meta-raspberrypi
 branch = master
 last_revision = b83766291188efb956c475b09c9666c2dfe2cb69
 
 [meta-security]
-src_uri = git://git.yoctoproject.org/meta-security
+src_uri = https://git.yoctoproject.org/meta-security
 dest_dir = upstream-layers/meta-security
 branch = master
 last_revision = bd6927e1dfc19b2b9619da85e03fb06b6fb6dc03
 
 [openembedded-core]
-src_uri = git://git.openembedded.org/openembedded-core
+src_uri = https://git.openembedded.org/openembedded-core
 dest_dir = upstream-layers/openembedded-core
 branch = master
 last_revision = 42fa856a00ac16b2a7a83d7ecfa60a5be192b16c
 
 [bitbake]
-src_uri = git://git.openembedded.org/bitbake
+src_uri = https://git.openembedded.org/bitbake
 dest_dir = upstream-layers/bitbake
 branch = 2.18
 last_revision = a82590d57b17e797575deb27ed29097d8713c9fa
 
 [yocto-docs]
-src_uri = git://git.yoctoproject.org/yocto-docs
+src_uri = https://git.yoctoproject.org/yocto-docs
 dest_dir = upstream-layers/yocto-docs
 branch = master
 last_revision = eb74fdfd9e5e579a65e8872d1a73b51e77b14f63


### PR DESCRIPTION
Yocto and OpenEmbedded seem to have disabled their git:// protocol
endpoints, but https:// works fine.  Switch to https:// in all of
our branches.

Signed-off-by: Patrick Williams <patrick@stwcx.xyz>
